### PR TITLE
[B2BORGS-69] Update cost centers dropdown after adding new cc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- After adding a cost center in the storefront UI, it will immediately be shown in the cost centers dropdown menu when adding or editing a user
+
 ## [1.0.0] - 2022-02-17
 
 ### Changed

--- a/react/components/EditUserModal.tsx
+++ b/react/components/EditUserModal.tsx
@@ -68,6 +68,7 @@ const EditUserModal: FunctionComponent<Props> = ({
 
   const { data: costCentersData } = useQuery(GET_COST_CENTERS, {
     variables: { id: organizationId, pageSize: 100 },
+    fetchPolicy: 'network-only',
     ssr: false,
   })
 
@@ -84,7 +85,7 @@ const EditUserModal: FunctionComponent<Props> = ({
       }
     )
 
-    setCostCenterOptions(options)
+    setCostCenterOptions([...options])
   }, [costCentersData])
 
   useEffect(() => {

--- a/react/components/NewUserModal.tsx
+++ b/react/components/NewUserModal.tsx
@@ -72,6 +72,7 @@ const NewUserModal: FunctionComponent<Props> = ({
 
   const { data: costCentersData } = useQuery(GET_COST_CENTERS, {
     variables: { id: organizationId, pageSize: 100 },
+    fetchPolicy: 'network-only',
     ssr: false,
   })
 
@@ -88,7 +89,7 @@ const NewUserModal: FunctionComponent<Props> = ({
       }
     )
 
-    setCostCenterOptions(options)
+    setCostCenterOptions([...options])
     setUserState({
       ...userState,
       costId: options[0].value,

--- a/react/components/OrganizationDetails.tsx
+++ b/react/components/OrganizationDetails.tsx
@@ -226,9 +226,11 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
     createCostCenter({ variables })
       .then(() => {
         setNewCostCenterModalState(false)
-        setLoadingState(false)
-        toastMessage(messages.toastAddCostCenterSuccess)
-        refetchCostCenters({ ...costCenterPaginationState })
+        setTimeout(() => {
+          setLoadingState(false)
+          toastMessage(messages.toastAddCostCenterSuccess)
+          refetchCostCenters({ ...costCenterPaginationState })
+        }, 500)
       })
       .catch(error => {
         setNewCostCenterModalState(false)
@@ -348,6 +350,7 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
         <OrganizationUsersTable
           organizationId={data.getOrganizationByIdStorefront?.id}
           permissions={permissionsState}
+          refetchCostCenters={loadingState}
         />
       </PageBlock>
       <NewCostCenterModal

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -14,6 +14,7 @@ import RemoveUserModal from './RemoveUserModal'
 interface Props {
   organizationId: string
   permissions: string[]
+  refetchCostCenters: boolean
 }
 
 interface CellRendererProps {
@@ -73,6 +74,7 @@ const messages = defineMessages({
 const OrganizationUsersTable: FunctionComponent<Props> = ({
   organizationId,
   permissions,
+  refetchCostCenters,
 }) => {
   const { formatMessage } = useIntl()
   const { showToast } = useContext(ToastContext)
@@ -257,22 +259,26 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
           },
         }}
       />
-      <NewUserModal
-        handleAddNewUser={handleAddUser}
-        handleCloseModal={handleCloseAddUserModal}
-        loading={addUserLoading}
-        isOpen={addUserModalOpen}
-        organizationId={organizationId}
-      />
-      <EditUserModal
-        handleUpdateUser={handleUpdateUser}
-        handleCloseModal={handleCloseUpdateUserModal}
-        handleRemoveUser={handleShowRemoveUserModal}
-        loading={updateUserLoading}
-        isOpen={editUserModalOpen}
-        organizationId={organizationId}
-        user={editUserDetails}
-      />
+      {refetchCostCenters ? null : (
+        <NewUserModal
+          handleAddNewUser={handleAddUser}
+          handleCloseModal={handleCloseAddUserModal}
+          loading={addUserLoading}
+          isOpen={addUserModalOpen}
+          organizationId={organizationId}
+        />
+      )}
+      {refetchCostCenters ? null : (
+        <EditUserModal
+          handleUpdateUser={handleUpdateUser}
+          handleCloseModal={handleCloseUpdateUserModal}
+          handleRemoveUser={handleShowRemoveUserModal}
+          loading={updateUserLoading}
+          isOpen={editUserModalOpen}
+          organizationId={organizationId}
+          user={editUserDetails}
+        />
+      )}
       <RemoveUserModal
         handleRemoveUser={handleRemoveUser}
         handleCloseModal={handleCloseRemoveUserModal}


### PR DESCRIPTION
#### What problem is this solving?

QA reported that when using the My Account > My Organization UI, if you add a new cost center and then immediately either attempt to add a user or edit an existing user, the newly created cost center was not shown in the dropdown and the user could not be assigned to it. 

This PR fixes the issue by disabling the GraphQL cache for the relevant queries and refetching the data after the cost center is created.

#### How to test it?

New version linked in https://b2bsuite--sandboxusdev.myvtex.com

Log in as an Organization Admin, go to My Account > My Organization, add a new cost center, then (without refreshing the page) try to add or edit a user. The new cost center should appear as an option in the dropdown within the modal. 