### PR TITLE
[B2BORG-77] Visual indicator for assigned selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Visual indicator for collections / payment terms / price tables that have been assigned to an organization (they now have a checkmark and are greyed out in the "available" list)
+
 ## [1.1.0] - 2022-03-08
 
 ### Added

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   Input,
   Modal,
+  IconCheck,
 } from 'vtex.styleguide'
 import { useToast } from '@vtex/admin-ui'
 import { useIntl, FormattedMessage, defineMessages } from 'react-intl'
@@ -604,13 +605,71 @@ const OrganizationDetails: FunctionComponent = () => {
     setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
   }
 
-  const getSchema = () => ({
-    properties: {
-      name: {
-        title: formatMessage(messages.columnName),
+  const getSchema = (
+    type?: 'availablePriceTables' | 'availableCollections' | 'availablePayments'
+  ) => {
+    let cellRenderer
+
+    switch (type) {
+      case 'availablePriceTables':
+        cellRenderer = ({ rowData: { name } }: CellRendererProps) => {
+          const assigned = priceTablesState.includes(name)
+
+          return (
+            <span className={assigned ? 'c-disabled' : ''}>
+              {name}
+              {assigned && <IconCheck />}
+            </span>
+          )
+        }
+
+        break
+
+      case 'availableCollections':
+        cellRenderer = ({ rowData: { name } }: CellRendererProps) => {
+          const assigned = collectionsState.some(
+            collection => collection.name === name
+          )
+
+          return (
+            <span className={assigned ? 'c-disabled' : ''}>
+              {name}
+              {assigned && <IconCheck />}
+            </span>
+          )
+        }
+
+        break
+
+      case 'availablePayments':
+        cellRenderer = ({ rowData: { name } }: CellRendererProps) => {
+          const assigned = paymentTermsState.some(
+            payment => payment.name === name
+          )
+
+          return (
+            <span className={assigned ? 'c-disabled' : ''}>
+              {name}
+              {assigned && <IconCheck />}
+            </span>
+          )
+        }
+
+        break
+
+      default:
+        break
+    }
+
+    return {
+      properties: {
+        name: {
+          title: formatMessage(messages.columnName),
+          ...(cellRenderer && { cellRenderer }),
+        },
       },
-    },
-  })
+    }
+  }
 
   const getCostCenterSchema = () => ({
     properties: {
@@ -790,7 +849,7 @@ const OrganizationDetails: FunctionComponent = () => {
           </h4>
           <Table
             fullWidth
-            schema={getSchema()}
+            schema={getSchema('availableCollections')}
             items={collectionOptions}
             pagination={{
               onNextClick: handleCollectionsNextClick,
@@ -858,7 +917,7 @@ const OrganizationDetails: FunctionComponent = () => {
           </h4>
           <Table
             fullWidth
-            schema={getSchema()}
+            schema={getSchema('availablePayments')}
             items={paymentTermsOptions}
             bulkActions={{
               texts: {
@@ -908,7 +967,7 @@ const OrganizationDetails: FunctionComponent = () => {
           </h4>
           <Table
             fullWidth
-            schema={getSchema()}
+            schema={getSchema('availablePriceTables')}
             items={priceTableOptions}
             bulkActions={{
               texts: {


### PR DESCRIPTION
#### What problem is this solving?

In the organizations admin panel, if a price table, payment term, or product collection is assigned to an organization, this PR updates the "Available" table to grey out the assigned option. To make it even more obvious that it has been assigned, a checkmark icon is also added next to the assigned option.

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/1574d7ea-1250-11ec-82ac-020154316047/

#### Screenshots or example usage:
<img width="986" alt="assigned" src="https://user-images.githubusercontent.com/6306265/157976581-682c69f4-4807-4198-9118-32abfc31913d.png">

