### PR TITLE
[B2BORG-85] Improve impersonation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added 
+### Added
 
 - docs/images folder and its files to illustrate the documentation
 
 ### Changed
 
 - README.md file, reviewing the documentation
+- When attempting to impersonate a user, frontend will no longer block impersonation if the `userId` is null. The impersonation mutation from `vtex.b2b-organizations-graphql` will attempt to determine the `userId` from the user's `clId`. If it can't, an error will be returned which will trigger the frontend to display an appropriate message.
 
 ## [1.2.0] - 2022-03-22
 
-### Added 
+### Added
 
 Added default shipping address UI option to my account and admin
 

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -344,19 +344,27 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
       return
     }
 
-    if (!rowData.userId) {
-      showToast(formatMessage(storeMessages.toastImpersonateIdMissing))
-
-      return
-    }
-
     showToast(formatMessage(storeMessages.toastImpersonateStarting))
 
     impersonateUser({
       variables: { clId: rowData.clId, userId: rowData.userId },
     })
-      .then(() => {
-        window.location.reload()
+      .then(result => {
+        if (result?.data?.impersonateUser?.status === 'error') {
+          console.error(
+            'Impersonation error:',
+            result.data.impersonateUser.message
+          )
+          if (
+            result.data.impersonateUser.message === 'userId not found in CL'
+          ) {
+            showToast(formatMessage(storeMessages.toastImpersonateIdMissing))
+          } else {
+            showToast(formatMessage(storeMessages.toastImpersonateFailure))
+          }
+        } else {
+          window.location.reload()
+        }
       })
       .catch(error => {
         console.error(error)


### PR DESCRIPTION
#### What problem is this solving?

When attempting to impersonate a user, frontend will no longer block impersonation if the user's `userId` is null. The impersonation mutation from `vtex.b2b-organizations-graphql` will attempt to determine the `userId` from the user's `clId`. If it can't, an error will be returned which will trigger the frontend to display an appropriate message.

Related to this PR: https://github.com/vtex-apps/b2b-organizations-graphql/pull/20

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com