### PR TITLE
[B2BORG-72] Disable GraphQL frontend cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `fetchPolicy: 'network-only'` to various queries to ensure fresh data
+
 ## [1.2.1] - 2022-03-24
 
 ### Added

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -213,6 +213,7 @@ const OrganizationDetails: FunctionComponent = () => {
     GET_COST_CENTERS,
     {
       variables: { ...costCenterPaginationState, id: params?.id },
+      fetchPolicy: 'network-only',
       skip: !params?.id,
       ssr: false,
     }

--- a/react/components/OrganizationDetails.tsx
+++ b/react/components/OrganizationDetails.tsx
@@ -131,6 +131,7 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
     refetch: refetchCostCenters,
   } = useQuery(GET_COST_CENTERS, {
     variables: { ...costCenterPaginationState },
+    fetchPolicy: 'network-only',
     ssr: false,
   })
 

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -181,6 +181,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
 
   const { data, loading, refetch } = useQuery(GET_USERS, {
     variables: { organizationId },
+    fetchPolicy: 'network-only',
     ssr: false,
     skip: !organizationId,
   })


### PR DESCRIPTION
#### What problem is this solving?

Our QA team reported a few UI bugs where changes to a cost center (i.e. deleting a cost center, or adding/removing addresses) would not be reflected in the list of cost centers if the user returned to the Organization Details page after performing the change. This PR fixes the issues by applying a "network-only" fetch policy to the "get cost centers" GraphQL query. It also adds it to the "get users" query just to be safe. 

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com

Delete a cost center (either in the admin or in the My Account > My Organization page) and then return to the list of cost centers. The cost center should no longer appear. 

Similarly, add or remove an address from a cost center, then return to the list of cost centers. The "addresses" column should show the new total number of addresses for that cost center.