### PR TITLE
[PERMISSION-26] Improve handling for impersonation expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added a sessionStorage remove item when a new impersonation or stop impersonation is called
+- Added a sessionStorage remove item "b2b-checkout-settings" when a new impersonation or stop impersonation is called
 
 ## [1.4.0] - 2022-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a sessionStorage remove item when a new impersonation or stop impersonation is called
+
 ## [1.4.0] - 2022-04-08
 
 ### Added

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -256,6 +256,10 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
 
     showToast(formatMessage(storeMessages.toastImpersonateStarting))
 
+    if (sessionStorage.getItem('b2b-checkout-settings')) {
+      sessionStorage.removeItem('b2b-checkout-settings')
+    }
+
     impersonateUser({
       variables: { clId: rowData.clId, userId: rowData.userId },
     })

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -15,6 +15,7 @@ import SAVE_USER from '../graphql/saveUser.graphql'
 import REMOVE_USER from '../graphql/removeUser.graphql'
 import GET_COST_CENTER from '../graphql/getCostCenterStorefront.graphql'
 import IMPERSONATE_USER from '../graphql/impersonateUser.graphql'
+import { B2B_CHECKOUT_SESSION_KEY } from '../utils/constants'
 
 interface Props {
   organizationId: string
@@ -256,8 +257,8 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
 
     showToast(formatMessage(storeMessages.toastImpersonateStarting))
 
-    if (sessionStorage.getItem('b2b-checkout-settings')) {
-      sessionStorage.removeItem('b2b-checkout-settings')
+    if (sessionStorage.getItem(B2B_CHECKOUT_SESSION_KEY)) {
+      sessionStorage.removeItem(B2B_CHECKOUT_SESSION_KEY)
     }
 
     impersonateUser({

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -14,6 +14,7 @@ import GET_ORGANIZATION from '../graphql/getOrganizationStorefront.graphql'
 import GET_COST_CENTER from '../graphql/getCostCenterStorefront.graphql'
 import CHECK_IMPERSONATION from '../graphql/checkImpersonation.graphql'
 import STOP_IMPERSONATION from '../graphql/impersonateUser.graphql'
+import { B2B_CHECKOUT_SESSION_KEY } from '../utils/constants'
 
 const CSS_HANDLES = [
   'userWidgetContainer',
@@ -77,8 +78,8 @@ const UserWidget: FunctionComponent = () => {
 
     stopImpersonation()
       .then(() => {
-        if (sessionStorage.getItem('b2b-checkout-settings')) {
-          sessionStorage.removeItem('b2b-checkout-settings')
+        if (sessionStorage.getItem(B2B_CHECKOUT_SESSION_KEY)) {
+          sessionStorage.removeItem(B2B_CHECKOUT_SESSION_KEY)
         }
 
         window.location.reload()

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -71,27 +71,16 @@ const UserWidget: FunctionComponent = () => {
 
   const [stopImpersonation] = useMutation(STOP_IMPERSONATION)
 
-  // useEffect(() => {
-  //   const handleImpersonationUpdated = () => refetch()
-
-  //   window.addEventListener('impersonationUpdated', handleImpersonationUpdated)
-
-  //   return () => {
-  //     window.removeEventListener(
-  //       'impersonationUpdated',
-  //       handleImpersonationUpdated
-  //     )
-  //   }
-  // }, [refetch])
-
   const handleStopImpersonation = async () => {
     setLoadingState(true)
     setErrorState(false)
 
     stopImpersonation()
       .then(() => {
-        // refetch()
-        // setLoadingState(false)
+        if (sessionStorage.getItem('b2b-checkout-settings')) {
+          sessionStorage.removeItem('b2b-checkout-settings')
+        }
+
         window.location.reload()
       })
       .catch(error => {
@@ -191,25 +180,6 @@ const UserWidget: FunctionComponent = () => {
               impersonationData.checkImpersonation.email
             }`}
           </div>
-          {/* <div
-            className={`${handles.userWidgetImpersonationItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
-          >
-            {`${formatMessage(messages.organization)} ${
-              impersonationData?.organizationName
-            }`}
-          </div>
-          <div
-            className={`${handles.userWidgetImpersonationItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
-          >
-            {`${formatMessage(messages.costCenter)} ${
-              impersonationData?.costCenterName
-            }`}
-          </div>
-          <div
-            className={`${handles.userWidgetImpersonationItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
-          >
-            {`${formatMessage(messages.role)} ${impersonationData?.role?.name}`}
-          </div> */}
           <div className={`${handles.userWidgetImpersonationButton} pa3`}>
             <Button
               variation="danger"
@@ -221,7 +191,7 @@ const UserWidget: FunctionComponent = () => {
             </Button>
             {errorState && (
               <div className={`${handles.userWidgetImpersonationError} error`}>
-                <FormattedMessage id="store/b2b-organizations.stop-impersonation-error"></FormattedMessage>
+                <FormattedMessage id="store/b2b-organizations.stop-impersonation-error" />
               </div>
             )}
           </div>

--- a/react/utils/constants.ts
+++ b/react/utils/constants.ts
@@ -1,0 +1,1 @@
+export const B2B_CHECKOUT_SESSION_KEY = 'b2b-checkout-settings'


### PR DESCRIPTION
#### What problem is this solving?

The current use of sessionStorage for user impersonation needs to be improved
This is related to what Sofia was reporting this morning while testing telemarketing app impersonation

#### Solution

Added a sessionStorage remove item (b2b-checkout-settings) when a new impersonation or stop impersonation is called

#### How to test it?

1) You have to start an impersonation by accessing your profile linked to the organization and then start an impersonation process.

<img width="1592" alt="image" src="https://user-images.githubusercontent.com/5812946/163580309-25ea3032-d138-421a-82bb-3c68de4c7978.png">

2) So you should add some product to the cart and then go to the checkout page

3) Opening the network and you are able to see the session storage as image below:

<img width="2669" alt="image" src="https://user-images.githubusercontent.com/5812946/163580584-b8c28b8f-dae7-470a-a751-ed773122720f.png">

4) Going back to the home page /, if you click on stop impersonation or start a new impersonation, the sessions storage should be empty after both processes.

<img width="1660" alt="image" src="https://user-images.githubusercontent.com/5812946/163580907-b29c5a2c-94df-491d-996f-70bc09f3d8fa.png">
