### PR TITLE
[B2BORG-90] add an optional makeDefault boolean variable to createCostCenterAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a new feature on creating the new address on the cost center which allows the user to set as the default address the new one.
+
 ## [1.5.0] - 2022-04-15
 
 ### Added

--- a/react/admin/CostCenterDetails.tsx
+++ b/react/admin/CostCenterDetails.tsx
@@ -252,7 +252,20 @@ const CostCenterDetails: FunctionComponent = () => {
       state: newAddressState.state.value,
       street: newAddressState.street.value,
       addressQuery: newAddressState.addressQuery.value,
+      checked: false,
     }
+
+    const newAddresses = [...addresses, newAddress]
+
+    setAddresses(
+      newAddresses.map(item => {
+        if (newAddressState.checked) {
+          item.checked = item === newAddress
+        }
+
+        return item
+      })
+    )
 
     setAddresses([...addresses, newAddress])
     handleCloseModals()
@@ -429,7 +442,7 @@ const CostCenterDetails: FunctionComponent = () => {
                           onChange={() => handleCheckDefault(address)}
                           checked={address.checked}
                           disabled={loadingState}
-                        ></Toggle>
+                        />
                       </div>
                     </div>
                     <div>
@@ -511,6 +524,18 @@ const CostCenterDetails: FunctionComponent = () => {
               omitAutoCompletedFields={false}
               omitPostalCodeFields
             />
+            <div className="mb6">
+              <Toggle
+                checked={newAddressState.checked}
+                onChange={() =>
+                  setNewAddressState((prevState: AddressFormFields) => ({
+                    ...newAddressState,
+                    checked: !prevState.checked,
+                  }))
+                }
+                label={formatMessage(messages.defaultAddress)}
+              />
+            </div>
           </AddressContainer>
         </AddressRules>
       </Modal>

--- a/react/components/CostCenterDetails.tsx
+++ b/react/components/CostCenterDetails.tsx
@@ -275,7 +275,18 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
       addressQuery: address.addressQuery.value,
     } as Address
 
-    setAddresses([...addresses, newAddress])
+    const newAddresses = [...addresses, newAddress]
+
+    setAddresses(
+      newAddresses.map(item => {
+        if (address.checked) {
+          item.checked = item === newAddress
+        }
+
+        return item
+      })
+    )
+
     handleCloseModals()
   }
 
@@ -497,7 +508,7 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
                       'create-cost-center-organization'
                     )
                   }
-                ></Toggle>
+                />
               </div>
             )
           })}
@@ -532,7 +543,7 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
                               'create-cost-center-organization'
                             ) || loadingState
                           }
-                        ></Toggle>
+                        />
                       </div>
                     </div>
                     <div>

--- a/react/components/NewAddressModal.tsx
+++ b/react/components/NewAddressModal.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react'
 import type { FunctionComponent } from 'react'
-import { Modal, Button } from 'vtex.styleguide'
+import React, { useEffect, useState } from 'react'
+import { Button, Modal, Toggle } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
 import {
-  AddressRules,
-  AddressForm,
   AddressContainer,
+  AddressForm,
+  AddressRules,
   CountrySelector,
   PostalCodeGetter,
 } from 'vtex.address-form'
@@ -38,9 +38,12 @@ const NewAddressModal: FunctionComponent<Props> = ({
 
   const { formatMessage } = useIntl()
 
-  const [newAddressState, setNewAddressState] = useState(() =>
-    addValidation(getEmptyAddress(country))
-  )
+  const [newAddressState, setNewAddressState] = useState(() => {
+    return {
+      ...addValidation(getEmptyAddress(country)),
+      checked: false,
+    }
+  })
 
   const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
 
@@ -53,10 +56,20 @@ const NewAddressModal: FunctionComponent<Props> = ({
     }))
   }
 
-  const handleNewAddressChange = (changedAddress: AddressFormFields) => {
-    const curAddress = newAddressState
+  useEffect(() => {
+    if (isOpen) {
+      setNewAddressState({
+        ...addValidation(getEmptyAddress(country)),
+        checked: false,
+      })
+    }
+  }, [isOpen])
 
-    const newAddress = { ...curAddress, ...changedAddress }
+  const handleNewAddressChange = (changedAddress: AddressFormFields) => {
+    const newAddress = {
+      ...newAddressState,
+      ...changedAddress,
+    }
 
     setNewAddressState(newAddress)
   }
@@ -111,6 +124,18 @@ const NewAddressModal: FunctionComponent<Props> = ({
             omitAutoCompletedFields={false}
             omitPostalCodeFields
           />
+          <div className="mb6">
+            <Toggle
+              checked={newAddressState.checked}
+              onChange={() =>
+                setNewAddressState((prevState: AddressFormFields) => ({
+                  ...newAddressState,
+                  checked: !prevState.checked,
+                }))
+              }
+              label={formatMessage(messages.defaultAddress)}
+            />
+          </div>
         </AddressContainer>
       </AddressRules>
     </Modal>


### PR DESCRIPTION
Added a new feature on creating the new address on the cost center which allows the user to set as the default address the new one.

#### What problem is this solving?

Add an optional makeDefault boolean variable to createCostCenterAddress which if true would add the address to the beginning of the array instead of the end


#### How to test it?

Workspace:
[https://b2borg--sandboxusdev.myvtex.com/](https://b2borg--sandboxusdev.myvtex.com/)

