### PR TITLE
Show trade polices as options in price table listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Include trade policies in price table listing
+
 ## [1.7.0] - 2022-04-28
 
 ### Added

--- a/react/graphql/getSalesChannels.graphql
+++ b/react/graphql/getSalesChannels.graphql
@@ -1,0 +1,6 @@
+query GetSalesChannels {
+  salesChannels @context(provider: "vtex.admin-graphql") {
+    id
+    name
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

Trade policies (AKA sales channels) also act as pricing tables, but only
the main one is included in the priceTables query. Introduce an
additional query to fetch the data for those and include it in the
display. This required a bit of tweaking of the UI logic since trade
policies have a display name plus a numerical id vs just a string name
for the regular price channels.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
I don't know if you can access it, but I've got it running in a workspace on the Whitebird store
[Workspace](https://witi167--whitebird.myvtex.com)