### PR TITLE
ADD Timeout for Cypress on GitHub Action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get Cypress Runner
-        run: git clone https://github.com/vtex-apps/cy-runner.git -b feature/multi-org
+        run: git clone https://github.com/vtex-apps/cy-runner.git
 
       - name: Cache
         uses: actions/cache@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   Cypress:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout App

--- a/cy-runner.yml
+++ b/cy-runner.yml
@@ -30,7 +30,7 @@ base:
     devMode: false
     runHeaded: false
     getCookies: true
-    maxJobs: 3
+    maxJobs: 2
     quiet: true
     projectId: 65uaim
     video: false


### PR DESCRIPTION
#### What problem is this solving?

As the execSync timeout option failed yesterday, this forces GitHub Action to kill after 30 minutes.