### PR TITLE
[B2BORG-91]  Add tabs to the UI for Organizations and Organization details screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added on the Organizations' page the navigation tabs to switch between organizations and organizations requests
+- Added on the Organizations details page the navigation tabs to switch between the components being organized
+
 ## [1.8.0] - 2022-05-02
 
 ### Added

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -7,7 +7,11 @@
   "subSectionItems": [
     {
       "labelId": "admin/b2b-organizations.organizations.navigation.label",
-      "path": "/admin/b2b-organizations/organizations"
+      "path": "/admin/b2b-organizations/organizations#/organizations"
+    },
+    {
+      "labelId": "admin/b2b-organizations.organization-requests.navigation.label",
+      "path": "/admin/b2b-organizations/organizations#/requests"
     }
   ]
 }

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -8,10 +8,6 @@
     {
       "labelId": "admin/b2b-organizations.organizations.navigation.label",
       "path": "/admin/b2b-organizations/organizations"
-    },
-    {
-      "labelId": "admin/b2b-organizations.organization-requests.navigation.label",
-      "path": "/admin/b2b-organizations/requests"
     }
   ]
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -93,6 +93,7 @@
   "admin/b2b-organizations.organization-details.remove-user": "admin/b2b-organizations.organization-details.remove-user",
   "admin/b2b-organizations.organization-details.remove-user.helpText": "admin/b2b-organizations.organization-details.remove-user.helpText",
   "admin/b2b-organizations.organization-details.default": "admin/b2b-organizations.organization-details.default",
+  "admin/b2b-organizations.organization-details.organization-name-required": "admin/b2b-organizations.organization-details.organization-name-required",
   "admin/b2b-organizations.costCenter-details.toast.update-success": "admin/b2b-organizations.costCenter-details.toast.update-success",
   "admin/b2b-organizations.costCenter-details.toast.update-failure": "admin/b2b-organizations.costCenter-details.toast.update-failure",
   "admin/b2b-organizations.costCenter-details.toast.delete-failure": "admin/b2b-organizations.costCenter-details.toast.delete-failure",

--- a/messages/context.json
+++ b/messages/context.json
@@ -92,6 +92,7 @@
   "admin/b2b-organizations.organization-details.edit-user": "admin/b2b-organizations.organization-details.edit-user",
   "admin/b2b-organizations.organization-details.remove-user": "admin/b2b-organizations.organization-details.remove-user",
   "admin/b2b-organizations.organization-details.remove-user.helpText": "admin/b2b-organizations.organization-details.remove-user.helpText",
+  "admin/b2b-organizations.organization-details.default": "admin/b2b-organizations.organization-details.default",
   "admin/b2b-organizations.costCenter-details.toast.update-success": "admin/b2b-organizations.costCenter-details.toast.update-success",
   "admin/b2b-organizations.costCenter-details.toast.update-failure": "admin/b2b-organizations.costCenter-details.toast.update-failure",
   "admin/b2b-organizations.costCenter-details.toast.delete-failure": "admin/b2b-organizations.costCenter-details.toast.delete-failure",

--- a/messages/en.json
+++ b/messages/en.json
@@ -92,6 +92,7 @@
   "admin/b2b-organizations.organization-details.edit-user": "Edit User",
   "admin/b2b-organizations.organization-details.remove-user": "Remove User",
   "admin/b2b-organizations.organization-details.remove-user.helpText": "Are you sure you want to remove the user {email}? Their user account will continue to exist, but they will no longer have access to this organization.",
+  "admin/b2b-organizations.organization-details.default": "General",
   "admin/b2b-organizations.costCenter-details.toast.update-success": "Cost center updated successfully",
   "admin/b2b-organizations.costCenter-details.toast.update-failure": "Update failed, see console for details",
   "admin/b2b-organizations.costCenter-details.toast.delete-failure": "Deletion failed, see console for details",

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,6 +93,7 @@
   "admin/b2b-organizations.organization-details.remove-user": "Remove User",
   "admin/b2b-organizations.organization-details.remove-user.helpText": "Are you sure you want to remove the user {email}? Their user account will continue to exist, but they will no longer have access to this organization.",
   "admin/b2b-organizations.organization-details.default": "General",
+  "admin/b2b-organizations.organization-details.organization-name-required": "The organization name is required.",
   "admin/b2b-organizations.costCenter-details.toast.update-success": "Cost center updated successfully",
   "admin/b2b-organizations.costCenter-details.toast.update-failure": "Update failed, see console for details",
   "admin/b2b-organizations.costCenter-details.toast.delete-failure": "Deletion failed, see console for details",

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -62,10 +62,6 @@ const OrganizationDetails: FunctionComponent = () => {
   )
 
   // const routerRef = useRef(null as any)
-  const { tab, handleTabChange, routerRef } = useHashRouter({
-    sessionKey: SESSION_STORAGE_KEY,
-    defaultPath: 'default',
-  })
 
   const [loadingState, setLoadingState] = useState(false)
 
@@ -223,6 +219,7 @@ const OrganizationDetails: FunctionComponent = () => {
   /**
    * Data Variables
    */
+
   const tabsList = [
     {
       label: formatMessage(messages.default),
@@ -290,6 +287,12 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
   ]
+
+  const { tab, handleTabChange, routerRef } = useHashRouter({
+    sessionKey: SESSION_STORAGE_KEY,
+    defaultPath: 'default',
+    routes: tabsList.map(_tab => _tab.tab),
+  })
 
   return (
     <Layout

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -1,30 +1,33 @@
-import type { FunctionComponent, ChangeEvent } from 'react'
-import React, { useEffect, useState } from 'react'
+import type { FunctionComponent } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation } from 'react-apollo'
 import {
   Layout,
   PageHeader,
-  PageBlock,
-  Table,
-  Dropdown,
-  Spinner,
   Button,
-  Input,
   IconCheck,
+  Tabs,
+  Tab,
+  Spinner,
+  PageBlock,
 } from 'vtex.styleguide'
 import { useToast } from '@vtex/admin-ui'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
+import { HashRouter, Route, Switch } from 'react-router-dom'
 
-import OrganizationUsersTable from '../components/OrganizationUsersTable'
 import { organizationMessages as messages } from './utils/messages'
 import GET_ORGANIZATION from '../graphql/getOrganization.graphql'
 import UPDATE_ORGANIZATION from '../graphql/updateOrganization.graphql'
-import GET_COLLECTIONS from '../graphql/getCollections.graphql'
-import GET_PAYMENT_TERMS from '../graphql/getPaymentTerms.graphql'
-import GET_PRICE_TABLES from '../graphql/getPriceTables.graphql'
-import GET_SALES_CHANNELS from '../graphql/getSalesChannels.graphql'
 import OrganizationDetailsConstCenters from './OrganizationDetails/OrganizationDetailsConstCenters'
+import type { Collection } from './OrganizationDetails/OrganizationDetailsCollections'
+import OrganizationDetailsCollections from './OrganizationDetails/OrganizationDetailsCollections'
+import type { PaymentTerm } from './OrganizationDetails/OrganizationDetailsPayTerms'
+import OrganizationDetailsPayTerms from './OrganizationDetails/OrganizationDetailsPayTerms'
+import type { PriceTable } from './OrganizationDetails/OrganizationDetailsPriceTables'
+import OrganizationDetailsPriceTables from './OrganizationDetails/OrganizationDetailsPriceTables'
+import OrganizationDetailsUsers from './OrganizationDetails/OrganizationDetailsUsers'
+import OrganizationDetailsDefault from './OrganizationDetails/OrganizationDetailsDefault'
 
 export interface CellRendererProps<RowType> {
   cellData: unknown
@@ -32,39 +35,13 @@ export interface CellRendererProps<RowType> {
   updateCellMeasurements: () => void
 }
 
-interface Collection {
-  collectionId: string
-  name: string
-}
-
-interface PriceTable {
-  tableId: string
-  name?: string
-}
-
-interface PaymentTerm {
-  paymentTermId: number
-  name: string
-}
+const SESSION_STORAGE_KEY = 'organization-details-tab'
 
 const OrganizationDetails: FunctionComponent = () => {
-  const { formatMessage, formatDate } = useIntl()
-
-  const statusOptions = [
-    {
-      value: 'active',
-      label: formatMessage(messages.statusActive),
-    },
-    {
-      value: 'on-hold',
-      label: formatMessage(messages.statusOnHold),
-    },
-    {
-      value: 'inactive',
-      label: formatMessage(messages.statusInactive),
-    },
-  ]
-
+  /**
+   * Hooks
+   */
+  const { formatMessage } = useIntl()
   const {
     route: { params },
     navigate,
@@ -72,176 +49,39 @@ const OrganizationDetails: FunctionComponent = () => {
 
   const showToast = useToast()
 
+  /**
+   * States
+   */
   const [organizationNameState, setOrganizationNameState] = useState('')
   const [statusState, setStatusState] = useState('')
   const [collectionsState, setCollectionsState] = useState([] as Collection[])
-  const [collectionOptions, setCollectionOptions] = useState([] as Collection[])
   const [priceTablesState, setPriceTablesState] = useState([] as string[])
-  const [priceTableOptions, setPriceTableOptions] = useState([] as PriceTable[])
-
-  const [collectionPaginationState, setCollectionPaginationState] = useState({
-    page: 1,
-    pageSize: 25,
-  })
-
   const [paymentTermsState, setPaymentTermsState] = useState(
     [] as PaymentTerm[]
   )
 
-  const [paymentTermsOptions, setPaymentTermsOptions] = useState(
-    [] as PaymentTerm[]
-  )
-
+  const routerRef = useRef(null as any)
   const [loadingState, setLoadingState] = useState(false)
+  const [tab, setTab] = useState('')
+  const [location, setLocation] = useState(null as any)
 
+  /**
+   * Queries
+   */
   const { data, loading, refetch } = useQuery(GET_ORGANIZATION, {
     variables: { id: params?.id },
     skip: !params?.id,
     ssr: false,
   })
 
-  const {
-    data: collectionsData,
-    refetch: refetchCollections,
-  } = useQuery(GET_COLLECTIONS, { ssr: false })
-
-  const { data: paymentTermsData } = useQuery<{
-    getPaymentTerms: PaymentTerm[]
-  }>(GET_PAYMENT_TERMS, { ssr: false })
-
-  const { data: priceTablesData } = useQuery(GET_PRICE_TABLES, { ssr: false })
-  const { data: salesChannelsData } = useQuery(GET_SALES_CHANNELS, {
-    ssr: false,
-  })
-
+  /**
+   * Mutations
+   */
   const [updateOrganization] = useMutation(UPDATE_ORGANIZATION)
 
-  useEffect(() => {
-    if (!data?.getOrganizationById || statusState) return
-
-    const collections =
-      data.getOrganizationById.collections?.map((collection: any) => {
-        return { name: collection.name, collectionId: collection.id }
-      }) ?? []
-
-    const paymentTerms =
-      data.getOrganizationById.paymentTerms?.map((paymentTerm: any) => {
-        return { name: paymentTerm.name, paymentTermId: paymentTerm.id }
-      }) ?? []
-
-    setOrganizationNameState(data.getOrganizationById.name)
-    setStatusState(data.getOrganizationById.status)
-    setCollectionsState(collections)
-    setPaymentTermsState(paymentTerms)
-    setPriceTablesState(data.getOrganizationById.priceTables ?? [])
-  }, [data])
-
-  useEffect(() => {
-    if (
-      !priceTablesData?.priceTables?.length ||
-      !salesChannelsData?.salesChannels?.length
-    ) {
-      return
-    }
-
-    const options = [] as PriceTable[]
-
-    salesChannelsData.salesChannels.forEach(
-      (channel: { id: string; name: string }) => {
-        options.push({
-          tableId: channel.id,
-          name: `${channel.name} (${channel.id})`,
-        })
-      }
-    )
-
-    priceTablesData.priceTables.forEach((priceTable: string) => {
-      if (!options.find(option => option.tableId === priceTable)) {
-        options.push({ tableId: priceTable })
-      }
-    })
-
-    setPriceTableOptions(options)
-  }, [priceTablesData, salesChannelsData])
-
-  useEffect(() => {
-    if (
-      !collectionsData?.collections?.items?.length ||
-      collectionOptions.length
-    ) {
-      return
-    }
-
-    const collections =
-      collectionsData.collections.items.map((collection: any) => {
-        return { name: collection.name, collectionId: collection.id }
-      }) ?? []
-
-    setCollectionOptions(collections)
-  }, [collectionsData])
-
-  useEffect(() => {
-    if (
-      !paymentTermsData?.getPaymentTerms?.length ||
-      paymentTermsOptions.length
-    ) {
-      return
-    }
-
-    const paymentTerms =
-      paymentTermsData.getPaymentTerms.map((paymentTerm: any) => {
-        return { name: paymentTerm.name, paymentTermId: paymentTerm.id }
-      }) ?? []
-
-    setPaymentTermsOptions(paymentTerms)
-  }, [paymentTermsData])
-
-  const handleCollectionsPrevClick = () => {
-    if (collectionPaginationState.page === 1) return
-
-    const newPage = collectionPaginationState.page - 1
-
-    setCollectionPaginationState({
-      ...collectionPaginationState,
-      page: newPage,
-    })
-
-    refetchCollections({
-      ...collectionPaginationState,
-      page: newPage,
-    })
-  }
-
-  const handleCollectionsNextClick = () => {
-    const newPage = collectionPaginationState.page + 1
-
-    setCollectionPaginationState({
-      ...collectionPaginationState,
-      page: newPage,
-    })
-
-    refetchCollections({
-      ...collectionPaginationState,
-      page: newPage,
-    })
-  }
-
-  const handleRowsChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const {
-      target: { value },
-    } = e
-
-    setCollectionPaginationState({
-      page: 1,
-      pageSize: +value,
-    })
-
-    refetchCollections({
-      page: 1,
-      pageSize: +value,
-    })
-  }
-
+  /**
+   * Functions
+   */
   const handleUpdateOrganization = () => {
     setLoadingState(true)
 
@@ -281,103 +121,18 @@ const OrganizationDetails: FunctionComponent = () => {
       })
   }
 
-  const handleAddCollections = (rowParams: any) => {
-    const { selectedRows = [] } = rowParams
-    const newCollections = [] as Collection[]
-
-    selectedRows.forEach((row: any) => {
-      if (
-        !collectionsState.some(
-          collection => collection.collectionId === row.collectionId
-        )
-      ) {
-        newCollections.push({ name: row.name, collectionId: row.collectionId })
-      }
-    })
-
-    setCollectionsState([...collectionsState, ...newCollections])
+  const setupTab = (_tab: string) => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, _tab)
+    setTab(_tab)
   }
 
-  const handleRemoveCollections = (rowParams: any) => {
-    const { selectedRows = [] } = rowParams
-    const collectionsToRemove = [] as string[]
+  const handleTabChange = (_tab: string) => {
+    if (!routerRef?.current) {
+      return
+    }
 
-    selectedRows.forEach((row: any) => {
-      collectionsToRemove.push(row.collectionId)
-    })
-
-    const newCollectionList = collectionsState.filter(
-      collection => !collectionsToRemove.includes(collection.collectionId)
-    )
-
-    setCollectionsState(newCollectionList)
-  }
-
-  const handleAddPaymentTerms = (rowParams: {
-    selectedRows: PaymentTerm[]
-  }) => {
-    const { selectedRows = [] } = rowParams
-    const newPaymentTerms = [] as PaymentTerm[]
-
-    selectedRows.forEach((row: any) => {
-      if (
-        !paymentTermsState.some(
-          paymentTerm => paymentTerm.paymentTermId === row.paymentTermId
-        )
-      ) {
-        newPaymentTerms.push({
-          name: row.name,
-          paymentTermId: row.paymentTermId,
-        })
-      }
-    })
-
-    setPaymentTermsState([...paymentTermsState, ...newPaymentTerms])
-  }
-
-  const handleRemovePaymentTerms = (rowParams: {
-    selectedRows: PaymentTerm[]
-  }) => {
-    const { selectedRows = [] } = rowParams
-    const paymentTermsToRemove = [] as number[]
-
-    selectedRows.forEach(row => {
-      paymentTermsToRemove.push(row.paymentTermId)
-    })
-
-    const newPaymentTerms = paymentTermsState.filter(
-      paymentTerm => !paymentTermsToRemove.includes(paymentTerm.paymentTermId)
-    )
-
-    setPaymentTermsState(newPaymentTerms)
-  }
-
-  const handleAddPriceTables = (rowParams: any) => {
-    const { selectedRows = [] } = rowParams
-    const newPriceTables = [] as string[]
-
-    selectedRows.forEach((row: PriceTable) => {
-      if (!priceTablesState.includes(row.tableId)) {
-        newPriceTables.push(row.tableId)
-      }
-    })
-
-    setPriceTablesState(prevState => [...prevState, ...newPriceTables])
-  }
-
-  const handleRemovePriceTables = (rowParams: any) => {
-    const { selectedRows = [] } = rowParams
-    const priceTablesToRemove = [] as string[]
-
-    selectedRows.forEach((row: PriceTable) => {
-      priceTablesToRemove.push(row.tableId)
-    })
-
-    const newPriceTablesList = priceTablesState.filter(
-      priceTable => !priceTablesToRemove.includes(priceTable)
-    )
-
-    setPriceTablesState(newPriceTablesList)
+    routerRef.current?.history?.push(`/${_tab}`)
+    setupTab(_tab)
   }
 
   const getSchema = (
@@ -452,32 +207,118 @@ const OrganizationDetails: FunctionComponent = () => {
     }
   }
 
-  if (!data) {
-    return (
-      <Layout
-        fullWidth
-        pageHeader={
-          <PageHeader
-            title={formatMessage(messages.detailsPageTitle)}
-            linkLabel={formatMessage(messages.back)}
-            onLinkClick={() => {
-              navigate({
-                page: 'admin.app.b2b-organizations.organizations',
-              })
-            }}
-          />
-        }
-      >
-        <PageBlock>
-          {loading ? (
-            <Spinner />
-          ) : (
-            <FormattedMessage id="admin/b2b-organizations.organization-details.empty-state" />
-          )}
-        </PageBlock>
-      </Layout>
-    )
-  }
+  /**
+   * Effects
+   */
+  useEffect(() => {
+    if (!data?.getOrganizationById || statusState) return
+
+    const collections =
+      data.getOrganizationById.collections?.map((collection: any) => {
+        return { name: collection.name, collectionId: collection.id }
+      }) ?? []
+
+    const paymentTerms =
+      data.getOrganizationById.paymentTerms?.map((paymentTerm: any) => {
+        return { name: paymentTerm.name, paymentTermId: paymentTerm.id }
+      }) ?? []
+
+    setOrganizationNameState(data.getOrganizationById.name)
+    setStatusState(data.getOrganizationById.status)
+    setCollectionsState(collections)
+    setPaymentTermsState(paymentTerms)
+    setPriceTablesState(data.getOrganizationById.priceTables ?? [])
+  }, [data])
+
+  useEffect(() => {
+    if (!location) return
+
+    setupTab(location.pathname.replace('/', ''))
+  }, [location])
+
+  useEffect(() => {
+    if (!routerRef?.current) return
+    if (routerRef.current?.history?.location.pathname === '/') {
+      const sessionTab = sessionStorage.getItem('organization-tab')
+
+      routerRef.current?.history?.push(
+        sessionTab ? `/${sessionTab}` : '/organizations'
+      )
+    }
+
+    setLocation(routerRef.current?.history?.location)
+  }, [routerRef])
+
+  /**
+   * Data Variables
+   */
+  const tabsList = [
+    {
+      label: 'Default',
+      tab: 'default',
+      component: (
+        <OrganizationDetailsDefault
+          organizationNameState={organizationNameState}
+          setOrganizationNameState={setOrganizationNameState}
+          statusState={statusState}
+          setStatusState={setStatusState}
+          data={data}
+        />
+      ),
+    },
+    {
+      label: 'Cost Centers',
+      tab: 'cost-centers',
+      component: (
+        <OrganizationDetailsConstCenters
+          setLoadingState={setLoadingState}
+          showToast={showToast}
+          loadingState={loadingState}
+        />
+      ),
+    },
+    {
+      label: 'Collections',
+      tab: 'collections',
+      component: (
+        <OrganizationDetailsCollections
+          getSchema={getSchema}
+          collectionsState={collectionsState}
+          setCollectionsState={setCollectionsState}
+        />
+      ),
+    },
+    {
+      label: 'Pay terms',
+      tab: 'pay-terms',
+
+      component: (
+        <OrganizationDetailsPayTerms
+          getSchema={getSchema}
+          paymentTermsState={paymentTermsState}
+          setPaymentTermsState={setPaymentTermsState}
+        />
+      ),
+    },
+    {
+      label: 'Price Tables',
+      tab: 'price-tables',
+      component: (
+        <OrganizationDetailsPriceTables
+          getSchema={getSchema}
+          priceTablesState={priceTablesState}
+          setPriceTablesState={setPriceTablesState}
+        />
+      ),
+    },
+    {
+      label: 'Users',
+      tab: 'users',
+      component: (
+        <OrganizationDetailsUsers params={params} loadingState={loadingState} />
+      ),
+    },
+  ]
 
   return (
     <Layout
@@ -502,255 +343,37 @@ const OrganizationDetails: FunctionComponent = () => {
         </PageHeader>
       }
     >
-      {/* <HashRouter ref={routerRef}> */}
-      {/*  <Tabs> */}
-      {/*    <Tab */}
-      {/*      label={formatMessage(messages.tablePageTitle)} */}
-      {/*      active={tab === 'organizations'} */}
-      {/*      onClick={() => handleTabChange('organizations')} */}
-      {/*    /> */}
-      {/*    <Tab */}
-      {/*      label={formatMessage(requestMessages.tablePageTitle)} */}
-      {/*      active={tab === 'requests'} */}
-      {/*      onClick={() => handleTabChange('requests')} */}
-      {/*    /> */}
-      {/*  </Tabs> */}
-      {/*  <Container> */}
-      {/*    <Switch> */}
-      {/*      <Route path="/organizations" exact component={OrganizationsList} /> */}
-      {/*      <Route */}
-      {/*        path="/requests" */}
-      {/*        exact */}
-      {/*        component={OrganizationRequestsTable} */}
-      {/*      /> */}
-      {/*    </Switch> */}
-      {/*  </Container> */}
-      {/* </HashRouter> */}
+      {loading ? (
+        <PageBlock>
+          <Spinner />
+        </PageBlock>
+      ) : (
+        (data && (
+          <HashRouter ref={routerRef}>
+            <Tabs>
+              {tabsList.map((item: { label: string; tab: string }) => (
+                <Tab
+                  label={item.label}
+                  active={tab === item.tab}
+                  onClick={() => handleTabChange(item.tab)}
+                />
+              ))}
+            </Tabs>
 
-      <PageBlock>
-        <Input
-          autocomplete="off"
-          size="large"
-          label={
-            <h4 className="t-heading-5 mb0 pt3">
-              <FormattedMessage id="admin/b2b-organizations.organization-details.organization-name" />
-            </h4>
-          }
-          value={organizationNameState}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setOrganizationNameState(e.target.value)
-          }}
-          required
-        />
-        <div className="pv3">
-          <Dropdown
-            label={
-              <h4 className="t-heading-5 mb0 pt3">
-                <FormattedMessage id="admin/b2b-organizations.organization-details.status" />
-              </h4>
-            }
-            placeholder={formatMessage(messages.status)}
-            options={statusOptions}
-            value={statusState}
-            onChange={(_: void, v: string) => setStatusState(v)}
-          />
-        </div>
-        <h4 className="t-heading-5 mb0 pt3">
-          <FormattedMessage id="admin/b2b-organizations.organization-details.created" />
-        </h4>
-        <div className="mv3">
-          {formatDate(data.getOrganizationById.created, {
-            day: 'numeric',
-            month: 'numeric',
-            year: 'numeric',
-          })}
-        </div>
-      </PageBlock>
-      <OrganizationDetailsConstCenters
-        setLoadingState={setLoadingState}
-        showToast={showToast}
-        loadingState={loadingState}
-      />
-      <PageBlock variation="half" title={formatMessage(messages.collections)}>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema()}
-            items={collectionsState}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemoveCollections(rowParams),
-              },
-            }}
-          />
-        </div>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema('availableCollections')}
-            items={collectionOptions}
-            pagination={{
-              onNextClick: handleCollectionsNextClick,
-              onPrevClick: handleCollectionsPrevClick,
-              onRowsChange: handleRowsChange,
-              currentItemFrom:
-                (collectionPaginationState.page - 1) *
-                  collectionPaginationState.pageSize +
-                1,
-              currentItemTo:
-                collectionsData?.collections?.paging?.total <
-                collectionPaginationState.page *
-                  collectionPaginationState.pageSize
-                  ? collectionsData?.collections?.paging?.total
-                  : collectionPaginationState.page *
-                    collectionPaginationState.pageSize,
-              textShowRows: formatMessage(messages.showRows),
-              textOf: formatMessage(messages.of),
-              totalItems: collectionsData?.collections?.paging?.total ?? 0,
-              rowsOptions: [25, 50, 100],
-            }}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddCollections(rowParams),
-              },
-            }}
-          />
-        </div>
-      </PageBlock>
-      <PageBlock variation="half" title={formatMessage(messages.paymentTerms)}>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema()}
-            items={paymentTermsState}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemovePaymentTerms(rowParams),
-              },
-            }}
-          />
-        </div>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema('availablePayments')}
-            items={paymentTermsOptions}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddPaymentTerms(rowParams),
-              },
-            }}
-          />
-        </div>
-      </PageBlock>
-      <PageBlock variation="half" title={formatMessage(messages.priceTables)}>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema()}
-            items={priceTablesState.map(priceTable => {
-              return {
-                tableId: priceTable,
-                name:
-                  priceTableOptions.find(
-                    option => option.tableId === priceTable
-                  )?.name ?? priceTable,
-              }
-            })}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemovePriceTables(rowParams),
-              },
-            }}
-          />
-        </div>
-        <div>
-          <h4 className="t-heading-4 mt0 mb0">
-            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
-          </h4>
-          <Table
-            fullWidth
-            schema={getSchema('availablePriceTables')}
-            items={priceTableOptions}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddPriceTables(rowParams),
-              },
-            }}
-          />
-        </div>
-      </PageBlock>
-      <PageBlock title={formatMessage(messages.users)}>
-        <OrganizationUsersTable
-          organizationId={params?.id}
-          permissions={[]}
-          refetchCostCenters={loadingState}
-          isAdmin={true}
-        />
-      </PageBlock>
+            <Switch>
+              {tabsList.map(({ tab: path, component }) => (
+                <Route path={`/${path}`} exact>
+                  {component}
+                </Route>
+              ))}
+            </Switch>
+          </HashRouter>
+        )) ?? (
+          <PageBlock>
+            <FormattedMessage id="admin/b2b-organizations.organization-details.empty-state" />
+          </PageBlock>
+        )
+      )}
     </Layout>
   )
 }

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -10,6 +10,7 @@ import {
   Tab,
   Spinner,
   PageBlock,
+  Alert,
 } from 'vtex.styleguide'
 import { useToast } from '@vtex/admin-ui'
 import { useIntl, FormattedMessage } from 'react-intl'
@@ -57,6 +58,7 @@ const OrganizationDetails: FunctionComponent = () => {
   const [statusState, setStatusState] = useState('')
   const [collectionsState, setCollectionsState] = useState([] as Collection[])
   const [priceTablesState, setPriceTablesState] = useState([] as string[])
+  const [errorState, setErrorState] = useState('')
   const [paymentTermsState, setPaymentTermsState] = useState(
     [] as PaymentTerm[]
   )
@@ -83,6 +85,14 @@ const OrganizationDetails: FunctionComponent = () => {
    * Functions
    */
   const handleUpdateOrganization = () => {
+    setErrorState('')
+
+    if (!organizationNameState || organizationNameState.trim().length === 0) {
+      setErrorState(formatMessage(messages.organizationNameRequired))
+
+      return
+    }
+
     setLoadingState(true)
 
     const collections = collectionsState.map(collection => {
@@ -333,7 +343,11 @@ const OrganizationDetails: FunctionComponent = () => {
                 />
               ))}
             </Tabs>
-
+            {errorState && errorState.length > 0 && (
+              <Alert type="error" className="mt6 mb6">
+                {errorState}
+              </Alert>
+            )}
             <Switch>
               {tabsList.map(({ tab: path, component }) => (
                 <Route path={`/${path}`} exact>

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useQuery, useMutation } from 'react-apollo'
 import {
   Layout,
@@ -61,10 +61,10 @@ const OrganizationDetails: FunctionComponent = () => {
     [] as PaymentTerm[]
   )
 
-  const routerRef = useRef(null as any)
-  const { tab, handleTabChange } = useHashRouter({
-    routerRef,
+  // const routerRef = useRef(null as any)
+  const { tab, handleTabChange, routerRef } = useHashRouter({
     sessionKey: SESSION_STORAGE_KEY,
+    defaultPath: 'default',
   })
 
   const [loadingState, setLoadingState] = useState(false)
@@ -225,7 +225,7 @@ const OrganizationDetails: FunctionComponent = () => {
    */
   const tabsList = [
     {
-      label: 'Default',
+      label: formatMessage(messages.default),
       tab: 'default',
       component: (
         <OrganizationDetailsDefault
@@ -238,7 +238,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Cost Centers',
+      label: formatMessage(messages.costCenters),
       tab: 'cost-centers',
       component: (
         <OrganizationDetailsConstCenters
@@ -249,7 +249,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Collections',
+      label: formatMessage(messages.collections),
       tab: 'collections',
       component: (
         <OrganizationDetailsCollections
@@ -260,7 +260,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Pay terms',
+      label: formatMessage(messages.paymentTerms),
       tab: 'pay-terms',
 
       component: (
@@ -272,7 +272,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Price Tables',
+      label: formatMessage(messages.priceTables),
       tab: 'price-tables',
       component: (
         <OrganizationDetailsPriceTables
@@ -283,7 +283,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Users',
+      label: formatMessage(messages.users),
       tab: 'users',
       component: (
         <OrganizationDetailsUsers params={params} loadingState={loadingState} />
@@ -334,7 +334,7 @@ const OrganizationDetails: FunctionComponent = () => {
             <Switch>
               {tabsList.map(({ tab: path, component }) => (
                 <Route path={`/${path}`} exact>
-                  {component}
+                  <div className="mt6">{component}</div>
                 </Route>
               ))}
             </Switch>

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -28,6 +28,7 @@ import type { PriceTable } from './OrganizationDetails/OrganizationDetailsPriceT
 import OrganizationDetailsPriceTables from './OrganizationDetails/OrganizationDetailsPriceTables'
 import OrganizationDetailsUsers from './OrganizationDetails/OrganizationDetailsUsers'
 import OrganizationDetailsDefault from './OrganizationDetails/OrganizationDetailsDefault'
+import useHashRouter from './OrganizationDetails/useHashRouter'
 
 export interface CellRendererProps<RowType> {
   cellData: unknown
@@ -61,9 +62,12 @@ const OrganizationDetails: FunctionComponent = () => {
   )
 
   const routerRef = useRef(null as any)
+  const { tab, handleTabChange } = useHashRouter({
+    routerRef,
+    sessionKey: SESSION_STORAGE_KEY,
+  })
+
   const [loadingState, setLoadingState] = useState(false)
-  const [tab, setTab] = useState('')
-  const [location, setLocation] = useState(null as any)
 
   /**
    * Queries
@@ -119,20 +123,6 @@ const OrganizationDetails: FunctionComponent = () => {
           message: formatMessage(messages.toastUpdateFailure),
         })
       })
-  }
-
-  const setupTab = (_tab: string) => {
-    sessionStorage.setItem(SESSION_STORAGE_KEY, _tab)
-    setTab(_tab)
-  }
-
-  const handleTabChange = (_tab: string) => {
-    if (!routerRef?.current) {
-      return
-    }
-
-    routerRef.current?.history?.push(`/${_tab}`)
-    setupTab(_tab)
   }
 
   const getSchema = (
@@ -229,25 +219,6 @@ const OrganizationDetails: FunctionComponent = () => {
     setPaymentTermsState(paymentTerms)
     setPriceTablesState(data.getOrganizationById.priceTables ?? [])
   }, [data])
-
-  useEffect(() => {
-    if (!location) return
-
-    setupTab(location.pathname.replace('/', ''))
-  }, [location])
-
-  useEffect(() => {
-    if (!routerRef?.current) return
-    if (routerRef.current?.history?.location.pathname === '/') {
-      const sessionTab = sessionStorage.getItem('organization-tab')
-
-      routerRef.current?.history?.push(
-        sessionTab ? `/${sessionTab}` : '/organizations'
-      )
-    }
-
-    setLocation(routerRef.current?.history?.location)
-  }, [routerRef])
 
   /**
    * Data Variables

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -1,0 +1,221 @@
+import type { ChangeEvent } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { PageBlock, Table } from 'vtex.styleguide'
+import { useQuery } from 'react-apollo'
+
+import { organizationMessages as messages } from '../utils/messages'
+import GET_COLLECTIONS from '../../graphql/getCollections.graphql'
+
+export interface Collection {
+  collectionId: string
+  name: string
+}
+
+const OrganizationDetailsCollections = ({
+  getSchema,
+  collectionsState,
+  setCollectionsState,
+}: {
+  getSchema: (argument?: any) => void
+  collectionsState: Collection[]
+  setCollectionsState: (value: any) => void
+}) => {
+  /**
+   * Hooks
+   */
+  const { formatMessage } = useIntl()
+  /**
+   * States
+   */
+
+  const [collectionOptions, setCollectionOptions] = useState([] as Collection[])
+  const [collectionPaginationState, setCollectionPaginationState] = useState({
+    page: 1,
+    pageSize: 25,
+  })
+
+  /**
+   * Queries
+   */
+  const {
+    data: collectionsData,
+    refetch: refetchCollections,
+  } = useQuery(GET_COLLECTIONS, { ssr: false })
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    if (
+      !collectionsData?.collections?.items?.length ||
+      collectionOptions.length
+    ) {
+      return
+    }
+
+    const collections =
+      collectionsData.collections.items.map((collection: any) => {
+        return { name: collection.name, collectionId: collection.id }
+      }) ?? []
+
+    setCollectionOptions(collections)
+  }, [collectionsData])
+
+  /**
+   * Functions
+   */
+  const handleRemoveCollections = (rowParams: any) => {
+    const { selectedRows = [] } = rowParams
+    const collectionsToRemove = [] as string[]
+
+    selectedRows.forEach((row: any) => {
+      collectionsToRemove.push(row.collectionId)
+    })
+
+    const newCollectionList = collectionsState.filter(
+      collection => !collectionsToRemove.includes(collection.collectionId)
+    )
+
+    setCollectionsState(newCollectionList)
+  }
+
+  const handleCollectionsPrevClick = () => {
+    if (collectionPaginationState.page === 1) return
+
+    const newPage = collectionPaginationState.page - 1
+
+    setCollectionPaginationState({
+      ...collectionPaginationState,
+      page: newPage,
+    })
+
+    refetchCollections({
+      ...collectionPaginationState,
+      page: newPage,
+    })
+  }
+
+  const handleCollectionsNextClick = () => {
+    const newPage = collectionPaginationState.page + 1
+
+    setCollectionPaginationState({
+      ...collectionPaginationState,
+      page: newPage,
+    })
+
+    refetchCollections({
+      ...collectionPaginationState,
+      page: newPage,
+    })
+  }
+
+  const handleRowsChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value },
+    } = e
+
+    setCollectionPaginationState({
+      page: 1,
+      pageSize: +value,
+    })
+
+    refetchCollections({
+      page: 1,
+      pageSize: +value,
+    })
+  }
+
+  const handleAddCollections = (rowParams: any) => {
+    const { selectedRows = [] } = rowParams
+    const newCollections = [] as Collection[]
+
+    selectedRows.forEach((row: any) => {
+      if (
+        !collectionsState.some(
+          collection => collection.collectionId === row.collectionId
+        )
+      ) {
+        newCollections.push({ name: row.name, collectionId: row.collectionId })
+      }
+    })
+
+    setCollectionsState([...collectionsState, ...newCollections])
+  }
+
+  return (
+    <Fragment>
+      <PageBlock variation="half" title={formatMessage(messages.collections)}>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema()}
+            items={collectionsState}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.removeFromOrg),
+                handleCallback: (rowParams: any) =>
+                  handleRemoveCollections(rowParams),
+              },
+            }}
+          />
+        </div>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema('availableCollections')}
+            items={collectionOptions}
+            pagination={{
+              onNextClick: handleCollectionsNextClick,
+              onPrevClick: handleCollectionsPrevClick,
+              onRowsChange: handleRowsChange,
+              currentItemFrom:
+                (collectionPaginationState.page - 1) *
+                  collectionPaginationState.pageSize +
+                1,
+              currentItemTo:
+                collectionsData?.collections?.paging?.total <
+                collectionPaginationState.page *
+                  collectionPaginationState.pageSize
+                  ? collectionsData?.collections?.paging?.total
+                  : collectionPaginationState.page *
+                    collectionPaginationState.pageSize,
+              textShowRows: formatMessage(messages.showRows),
+              textOf: formatMessage(messages.of),
+              totalItems: collectionsData?.collections?.paging?.total ?? 0,
+              rowsOptions: [25, 50, 100],
+            }}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.addToOrg),
+                handleCallback: (rowParams: any) =>
+                  handleAddCollections(rowParams),
+              },
+            }}
+          />
+        </div>
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsCollections

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -17,7 +17,7 @@ const OrganizationDetailsCollections = ({
   collectionsState,
   setCollectionsState,
 }: {
-  getSchema: (argument?: any) => void
+  getSchema: (argument?: any) => any
   collectionsState: Collection[]
   setCollectionsState: (value: any) => void
 }) => {
@@ -144,6 +144,21 @@ const OrganizationDetailsCollections = ({
     setCollectionsState([...collectionsState, ...newCollections])
   }
 
+  const bulkActions = (handleCallback: (params: any) => void) => {
+    return {
+      texts: {
+        rowsSelected: (qty: number) =>
+          formatMessage(messages.selectedRows, {
+            qty,
+          }),
+      },
+      main: {
+        label: formatMessage(messages.removeFromOrg),
+        handleCallback,
+      },
+    }
+  }
+
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.collections)}>
@@ -155,19 +170,7 @@ const OrganizationDetailsCollections = ({
             fullWidth
             schema={getSchema()}
             items={collectionsState}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemoveCollections(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleRemoveCollections)}
           />
         </div>
         <div>
@@ -198,19 +201,7 @@ const OrganizationDetailsCollections = ({
               totalItems: collectionsData?.collections?.paging?.total ?? 0,
               rowsOptions: [25, 50, 100],
             }}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddCollections(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleAddCollections)}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsConstCenters.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsConstCenters.tsx
@@ -1,0 +1,369 @@
+import type { ChangeEvent } from 'react'
+import React, { Fragment, useState } from 'react'
+import { Button, Input, Modal, PageBlock, Table } from 'vtex.styleguide'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { useMutation, useQuery } from 'react-apollo'
+import { useRuntime } from 'vtex.render-runtime'
+import { addValidation } from 'vtex.address-form/helpers'
+import {
+  AddressContainer,
+  AddressForm,
+  AddressRules,
+  CountrySelector,
+  PostalCodeGetter,
+} from 'vtex.address-form'
+import { StyleguideInput } from 'vtex.address-form/inputs'
+import type { Toast } from '@vtex/admin-ui/dist/components/Toast/types'
+
+import GET_COST_CENTERS from '../../graphql/getCostCentersByOrganizationId.graphql'
+import type { CellRendererProps } from '../OrganizationDetails'
+import { organizationMessages as messages } from '../utils/messages'
+import { getEmptyAddress, isValidAddress } from '../../utils/addresses'
+import CREATE_COST_CENTER from '../../graphql/createCostCenter.graphql'
+import GET_LOGISTICS from '../../graphql/getLogistics.graphql'
+
+interface CostCenterSimple {
+  id: string
+  name: string
+  addresses: Address[]
+}
+
+const OrganizationDetailsConstCenters = ({
+  setLoadingState,
+  showToast,
+  loadingState,
+}: {
+  setLoadingState: (state: boolean) => void
+  showToast: (toast: Toast) => void
+  loadingState: boolean
+}) => {
+  /**
+   * Hooks
+   */
+  const {
+    culture: { country },
+    route: { params },
+    navigate,
+  } = useRuntime()
+
+  const { formatMessage } = useIntl()
+
+  /**
+   * States
+   */
+  const [costCenterPaginationState, setCostCenterPaginationState] = useState({
+    page: 1,
+    pageSize: 25,
+  })
+
+  const [newCostCenterModalState, setNewCostCenterModalState] = useState(false)
+  const [newCostCenterName, setNewCostCenterName] = useState('')
+  const [
+    newCostCenterBusinessDocument,
+    setNewCostCenterBusinessDocument,
+  ] = useState('')
+
+  const [newCostCenterAddressState, setNewCostCenterAddressState] = useState(
+    addValidation(getEmptyAddress(country))
+  )
+
+  /**
+   * Mutations
+   */
+  const [createCostCenter] = useMutation(CREATE_COST_CENTER)
+  const { data: costCentersData, refetch: refetchCostCenters } = useQuery(
+    GET_COST_CENTERS,
+    {
+      variables: { ...costCenterPaginationState, id: params?.id },
+      fetchPolicy: 'network-only',
+      skip: !params?.id,
+      ssr: false,
+    }
+  )
+
+  /**
+   * Functions
+   */
+  const handleCostCentersRowsChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value },
+    } = e
+
+    setCostCenterPaginationState({
+      page: 1,
+      pageSize: +value,
+    })
+
+    refetchCostCenters({
+      id: params?.id,
+      page: 1,
+      pageSize: +value,
+    })
+  }
+
+  const handleAddNewCostCenter = () => {
+    setLoadingState(true)
+    const newAddress = {
+      addressId: newCostCenterAddressState.addressId.value,
+      addressType: newCostCenterAddressState.addressType.value,
+      city: newCostCenterAddressState.city.value,
+      complement: newCostCenterAddressState.complement.value,
+      country: newCostCenterAddressState.country.value,
+      receiverName: newCostCenterAddressState.receiverName.value,
+      geoCoordinates: newCostCenterAddressState.geoCoordinates.value,
+      neighborhood: newCostCenterAddressState.neighborhood.value,
+      number: newCostCenterAddressState.number.value,
+      postalCode: newCostCenterAddressState.postalCode.value,
+      reference: newCostCenterAddressState.reference.value,
+      state: newCostCenterAddressState.state.value,
+      street: newCostCenterAddressState.street.value,
+      addressQuery: newCostCenterAddressState.addressQuery.value,
+    }
+
+    const variables = {
+      organizationId: params.id,
+      input: {
+        name: newCostCenterName,
+        addresses: [newAddress],
+        businessDocument: newCostCenterBusinessDocument,
+      },
+    }
+
+    createCostCenter({ variables })
+      .then(() => {
+        setNewCostCenterModalState(false)
+        setLoadingState(false)
+        showToast({
+          type: 'success',
+          message: formatMessage(messages.toastAddCostCenterSuccess),
+        })
+        refetchCostCenters({ ...costCenterPaginationState, id: params?.id })
+      })
+      .catch(error => {
+        setNewCostCenterModalState(false)
+        setLoadingState(false)
+        console.error(error)
+        showToast({
+          type: 'error',
+          message: formatMessage(messages.toastAddCostCenterFailure),
+        })
+      })
+  }
+
+  const handleCostCentersPrevClick = () => {
+    if (costCenterPaginationState.page === 1) return
+
+    const newPage = costCenterPaginationState.page - 1
+
+    setCostCenterPaginationState({
+      ...costCenterPaginationState,
+      page: newPage,
+    })
+
+    refetchCostCenters({
+      ...costCenterPaginationState,
+      id: params?.id,
+      page: newPage,
+    })
+  }
+
+  const handleCostCentersNextClick = () => {
+    const newPage = costCenterPaginationState.page + 1
+
+    setCostCenterPaginationState({
+      ...costCenterPaginationState,
+      page: newPage,
+    })
+
+    refetchCostCenters({
+      ...costCenterPaginationState,
+      id: params?.id,
+      page: newPage,
+    })
+  }
+
+  const getCostCenterSchema = () => ({
+    properties: {
+      name: {
+        title: formatMessage(messages.detailsColumnName),
+      },
+      addresses: {
+        title: formatMessage(messages.columnAddresses),
+        cellRenderer: ({
+          rowData: { addresses },
+        }: CellRendererProps<CostCenterSimple>) => (
+          <span>{addresses.length}</span>
+        ),
+      },
+    },
+  })
+
+  const handleNewCostCenterAddressChange = (
+    changedAddress: AddressFormFields
+  ) => {
+    const curAddress = newCostCenterAddressState
+
+    const newAddress = { ...curAddress, ...changedAddress }
+
+    setNewCostCenterAddressState(newAddress)
+  }
+
+  const handleCloseModal = () => {
+    setNewCostCenterModalState(false)
+    setNewCostCenterName('')
+    setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
+  }
+
+  const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
+
+  const translateCountries = () => {
+    const { shipsTo = [] } = logisticsData?.logistics ?? {}
+
+    return shipsTo.map((code: string) => ({
+      label: formatMessage({ id: `country.${code}` }),
+      value: code,
+    }))
+  }
+
+  /**
+   * View
+   */
+  return (
+    <Fragment>
+      <PageBlock title={formatMessage(messages.costCenters)}>
+        <Table
+          fullWidth
+          schema={getCostCenterSchema()}
+          items={costCentersData?.getCostCentersByOrganizationId?.data}
+          onRowClick={({
+            rowData: { id },
+          }: CellRendererProps<CostCenterSimple>) => {
+            if (!id) return
+
+            navigate({
+              page: 'admin.app.b2b-organizations.costCenter-details',
+              params: { id },
+            })
+          }}
+          pagination={{
+            onNextClick: handleCostCentersNextClick,
+            onPrevClick: handleCostCentersPrevClick,
+            onRowsChange: handleCostCentersRowsChange,
+            currentItemFrom:
+              (costCenterPaginationState.page - 1) *
+                costCenterPaginationState.pageSize +
+              1,
+            currentItemTo:
+              costCentersData?.getCostCentersByOrganizationId?.pagination
+                ?.total <
+              costCenterPaginationState.page *
+                costCenterPaginationState.pageSize
+                ? costCentersData?.getCostCentersByOrganizationId?.pagination
+                    ?.total
+                : costCenterPaginationState.page *
+                  costCenterPaginationState.pageSize,
+            textShowRows: formatMessage(messages.showRows),
+            textOf: formatMessage(messages.of),
+            totalItems:
+              costCentersData?.getCostCentersByOrganizationId?.pagination
+                ?.total ?? 0,
+            rowsOptions: [25, 50, 100],
+          }}
+          toolbar={{
+            newLine: {
+              label: formatMessage(messages.new),
+              handleCallback: () => setNewCostCenterModalState(true),
+            },
+          }}
+        />
+      </PageBlock>
+      <Modal
+        centered
+        bottomBar={
+          <div className="nowrap">
+            <span className="mr4">
+              <Button
+                variation="tertiary"
+                onClick={() => handleCloseModal()}
+                disabled={loadingState}
+              >
+                {formatMessage(messages.cancel)}
+              </Button>
+            </span>
+            <span>
+              <Button
+                variation="primary"
+                onClick={() => handleAddNewCostCenter()}
+                isLoading={loadingState}
+                disabled={
+                  !newCostCenterName ||
+                  !isValidAddress(newCostCenterAddressState)
+                }
+              >
+                {formatMessage(messages.add)}
+              </Button>
+            </span>
+          </div>
+        }
+        isOpen={newCostCenterModalState}
+        onClose={() => handleCloseModal()}
+        closeOnOverlayClick={false}
+      >
+        <p className="f3 f1-ns fw3 gray">
+          <FormattedMessage id="admin/b2b-organizations.organization-details.add-costCenter" />
+        </p>
+        <div className="w-100 mv6">
+          <Input
+            autocomplete="off"
+            size="large"
+            label={formatMessage(messages.costCenterName)}
+            value={newCostCenterName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterName(e.target.value)
+            }}
+            required
+          />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            autocomplete="off"
+            size="large"
+            label={formatMessage(messages.businessDocument)}
+            helpText={formatMessage(messages.businessDocumentHelp)}
+            value={newCostCenterBusinessDocument}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterBusinessDocument(e.target.value)
+            }}
+          />
+        </div>
+        <div className="w-100 mv6">
+          <FormattedMessage id="admin/b2b-organizations.organization-details.add-costCenter.helpText" />
+        </div>
+        <AddressRules
+          country={newCostCenterAddressState?.country?.value}
+          shouldUseIOFetching
+          useGeolocation={false}
+        >
+          <AddressContainer
+            address={newCostCenterAddressState}
+            Input={StyleguideInput}
+            onChangeAddress={handleNewCostCenterAddressChange}
+            autoCompletePostalCode
+          >
+            <CountrySelector shipsTo={translateCountries()} />
+
+            <PostalCodeGetter />
+
+            <AddressForm
+              Input={StyleguideInput}
+              omitAutoCompletedFields={false}
+              omitPostalCodeFields
+            />
+          </AddressContainer>
+        </AddressRules>
+      </Modal>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsConstCenters

--- a/react/admin/OrganizationDetails/OrganizationDetailsDefault.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsDefault.tsx
@@ -1,0 +1,82 @@
+import { Dropdown, Input, PageBlock } from 'vtex.styleguide'
+import { FormattedMessage, useIntl } from 'react-intl'
+import React, { Fragment } from 'react'
+
+import { organizationMessages as messages } from '../utils/messages'
+
+const OrganizationDetailsDefault = ({
+  organizationNameState,
+  setOrganizationNameState,
+  statusState,
+  setStatusState,
+  data,
+}: any) => {
+  /**
+   * Hooks
+   */
+  const { formatMessage, formatDate } = useIntl()
+
+  /**
+   * States
+   */
+  const statusOptions = [
+    {
+      value: 'active',
+      label: formatMessage(messages.statusActive),
+    },
+    {
+      value: 'on-hold',
+      label: formatMessage(messages.statusOnHold),
+    },
+    {
+      value: 'inactive',
+      label: formatMessage(messages.statusInactive),
+    },
+  ]
+
+  return (
+    <Fragment>
+      <PageBlock>
+        <Input
+          autocomplete="off"
+          size="large"
+          label={
+            <h4 className="t-heading-5 mb0 pt3">
+              <FormattedMessage id="admin/b2b-organizations.organization-details.organization-name" />
+            </h4>
+          }
+          value={organizationNameState}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setOrganizationNameState(e.target.value)
+          }}
+          required
+        />
+        <div className="pv3">
+          <Dropdown
+            label={
+              <h4 className="t-heading-5 mb0 pt3">
+                <FormattedMessage id="admin/b2b-organizations.organization-details.status" />
+              </h4>
+            }
+            placeholder={formatMessage(messages.status)}
+            options={statusOptions}
+            value={statusState}
+            onChange={(_: void, v: string) => setStatusState(v)}
+          />
+        </div>
+        <h4 className="t-heading-5 mb0 pt3">
+          <FormattedMessage id="admin/b2b-organizations.organization-details.created" />
+        </h4>
+        <div className="mv3">
+          {formatDate(data.getOrganizationById.created, {
+            day: 'numeric',
+            month: 'numeric',
+            year: 'numeric',
+          })}
+        </div>
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsDefault

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -103,6 +103,21 @@ const OrganizationDetailsPayTerms = ({
     setPaymentTermsState([...paymentTermsState, ...newPaymentTerms])
   }
 
+  const bulkActions = (handleCallback: (params: any) => void) => {
+    return {
+      texts: {
+        rowsSelected: (qty: number) =>
+          formatMessage(messages.selectedRows, {
+            qty,
+          }),
+      },
+      main: {
+        label: formatMessage(messages.removeFromOrg),
+        handleCallback,
+      },
+    }
+  }
+
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.paymentTerms)}>
@@ -114,19 +129,7 @@ const OrganizationDetailsPayTerms = ({
             fullWidth
             schema={getSchema()}
             items={paymentTermsState}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemovePaymentTerms(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleRemovePaymentTerms)}
           />
         </div>
         <div>
@@ -137,19 +140,7 @@ const OrganizationDetailsPayTerms = ({
             fullWidth
             schema={getSchema('availablePayments')}
             items={paymentTermsOptions}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddPaymentTerms(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleAddPaymentTerms)}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -1,0 +1,160 @@
+import { FormattedMessage, useIntl } from 'react-intl'
+import { PageBlock, Table } from 'vtex.styleguide'
+import React, { Fragment, useEffect, useState } from 'react'
+import { useQuery } from 'react-apollo'
+
+import { organizationMessages as messages } from '../utils/messages'
+import GET_PAYMENT_TERMS from '../../graphql/getPaymentTerms.graphql'
+
+export interface PaymentTerm {
+  paymentTermId: number
+  name: string
+}
+
+const OrganizationDetailsPayTerms = ({
+  getSchema,
+  paymentTermsState,
+  setPaymentTermsState,
+}: {
+  getSchema: (argument?: any) => any
+  paymentTermsState: PaymentTerm[]
+  setPaymentTermsState: (value: any) => void
+}) => {
+  /**
+   * Hooks
+   */
+  const { formatMessage } = useIntl()
+  /**
+   * States
+   */
+
+  const [paymentTermsOptions, setPaymentTermsOptions] = useState(
+    [] as PaymentTerm[]
+  )
+
+  /**
+   * Queries
+   */
+
+  const { data: paymentTermsData } = useQuery<{
+    getPaymentTerms: PaymentTerm[]
+  }>(GET_PAYMENT_TERMS, { ssr: false })
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    if (
+      !paymentTermsData?.getPaymentTerms?.length ||
+      paymentTermsOptions.length
+    ) {
+      return
+    }
+
+    const paymentTerms =
+      paymentTermsData.getPaymentTerms.map((paymentTerm: any) => {
+        return { name: paymentTerm.name, paymentTermId: paymentTerm.id }
+      }) ?? []
+
+    setPaymentTermsOptions(paymentTerms)
+  }, [paymentTermsData])
+
+  /**
+   * Functions
+   */
+
+  const handleRemovePaymentTerms = (rowParams: {
+    selectedRows: PaymentTerm[]
+  }) => {
+    const { selectedRows = [] } = rowParams
+    const paymentTermsToRemove = [] as number[]
+
+    selectedRows.forEach(row => {
+      paymentTermsToRemove.push(row.paymentTermId)
+    })
+
+    const newPaymentTerms = paymentTermsState.filter(
+      paymentTerm => !paymentTermsToRemove.includes(paymentTerm.paymentTermId)
+    )
+
+    setPaymentTermsState(newPaymentTerms)
+  }
+
+  const handleAddPaymentTerms = (rowParams: {
+    selectedRows: PaymentTerm[]
+  }) => {
+    const { selectedRows = [] } = rowParams
+    const newPaymentTerms = [] as PaymentTerm[]
+
+    selectedRows.forEach((row: any) => {
+      if (
+        !paymentTermsState.some(
+          paymentTerm => paymentTerm.paymentTermId === row.paymentTermId
+        )
+      ) {
+        newPaymentTerms.push({
+          name: row.name,
+          paymentTermId: row.paymentTermId,
+        })
+      }
+    })
+
+    setPaymentTermsState([...paymentTermsState, ...newPaymentTerms])
+  }
+
+  return (
+    <Fragment>
+      <PageBlock variation="half" title={formatMessage(messages.paymentTerms)}>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema()}
+            items={paymentTermsState}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.removeFromOrg),
+                handleCallback: (rowParams: any) =>
+                  handleRemovePaymentTerms(rowParams),
+              },
+            }}
+          />
+        </div>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema('availablePayments')}
+            items={paymentTermsOptions}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.addToOrg),
+                handleCallback: (rowParams: any) =>
+                  handleAddPaymentTerms(rowParams),
+              },
+            }}
+          />
+        </div>
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsPayTerms

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -1,0 +1,166 @@
+import React, { Fragment, useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { PageBlock, Table } from 'vtex.styleguide'
+import { useQuery } from 'react-apollo'
+
+import { organizationMessages as messages } from '../utils/messages'
+import GET_PRICE_TABLES from '../../graphql/getPriceTables.graphql'
+import GET_SALES_CHANNELS from '../../graphql/getSalesChannels.graphql'
+
+export interface PriceTable {
+  tableId: string
+  name?: string
+}
+
+const OrganizationDetailsPriceTables = ({
+  getSchema,
+  priceTablesState,
+  setPriceTablesState,
+}: {
+  getSchema: (argument?: any) => any
+  priceTablesState: string[]
+  setPriceTablesState: (value: any) => void
+}) => {
+  /**
+   * Hooks
+   */
+  const { formatMessage } = useIntl()
+
+  /**
+   * States
+   */
+  const [priceTableOptions, setPriceTableOptions] = useState([] as PriceTable[])
+
+  /**
+   * Queries
+   */
+  const { data: priceTablesData } = useQuery(GET_PRICE_TABLES, { ssr: false })
+  const { data: salesChannelsData } = useQuery(GET_SALES_CHANNELS, {
+    ssr: false,
+  })
+
+  /**
+   * Effects
+   */
+  useEffect(() => {
+    if (
+      !priceTablesData?.priceTables?.length ||
+      !salesChannelsData?.salesChannels?.length
+    ) {
+      return
+    }
+
+    const options = [] as PriceTable[]
+
+    salesChannelsData.salesChannels.forEach(
+      (channel: { id: string; name: string }) => {
+        options.push({
+          tableId: channel.id,
+          name: `${channel.name} (${channel.id})`,
+        })
+      }
+    )
+
+    priceTablesData.priceTables.forEach((priceTable: string) => {
+      if (!options.find(option => option.tableId === priceTable)) {
+        options.push({ tableId: priceTable })
+      }
+    })
+
+    setPriceTableOptions(options)
+  }, [priceTablesData, salesChannelsData])
+
+  /**
+   * Functions
+   */
+  const handleRemovePriceTables = (rowParams: any) => {
+    const { selectedRows = [] } = rowParams
+    const priceTablesToRemove = [] as string[]
+
+    selectedRows.forEach((row: PriceTable) => {
+      priceTablesToRemove.push(row.tableId)
+    })
+
+    const newPriceTablesList = priceTablesState.filter(
+      priceTable => !priceTablesToRemove.includes(priceTable)
+    )
+
+    setPriceTablesState(newPriceTablesList)
+  }
+
+  const handleAddPriceTables = (rowParams: any) => {
+    const { selectedRows = [] } = rowParams
+    const newPriceTables = [] as string[]
+
+    selectedRows.forEach((row: PriceTable) => {
+      if (!priceTablesState.includes(row.tableId)) {
+        newPriceTables.push(row.tableId)
+      }
+    })
+
+    setPriceTablesState((prevState: any) => [...prevState, ...newPriceTables])
+  }
+
+  return (
+    <Fragment>
+      <PageBlock variation="half" title={formatMessage(messages.priceTables)}>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.assigned-to-org" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema()}
+            items={priceTablesState.map(priceTable => {
+              return {
+                tableId: priceTable,
+                name:
+                  priceTableOptions.find(
+                    option => option.tableId === priceTable
+                  )?.name ?? priceTable,
+              }
+            })}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.removeFromOrg),
+                handleCallback: (rowParams: any) =>
+                  handleRemovePriceTables(rowParams),
+              },
+            }}
+          />
+        </div>
+        <div>
+          <h4 className="t-heading-4 mt0 mb0">
+            <FormattedMessage id="admin/b2b-organizations.organization-details.available" />
+          </h4>
+          <Table
+            fullWidth
+            schema={getSchema('availablePriceTables')}
+            items={priceTableOptions}
+            bulkActions={{
+              texts: {
+                rowsSelected: (qty: number) =>
+                  formatMessage(messages.selectedRows, {
+                    qty,
+                  }),
+              },
+              main: {
+                label: formatMessage(messages.addToOrg),
+                handleCallback: (rowParams: any) =>
+                  handleAddPriceTables(rowParams),
+              },
+            }}
+          />
+        </div>
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsPriceTables

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -101,6 +101,21 @@ const OrganizationDetailsPriceTables = ({
     setPriceTablesState((prevState: any) => [...prevState, ...newPriceTables])
   }
 
+  const bulkActions = (handleCallback: (params: any) => void) => {
+    return {
+      texts: {
+        rowsSelected: (qty: number) =>
+          formatMessage(messages.selectedRows, {
+            qty,
+          }),
+      },
+      main: {
+        label: formatMessage(messages.removeFromOrg),
+        handleCallback,
+      },
+    }
+  }
+
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.priceTables)}>
@@ -120,19 +135,7 @@ const OrganizationDetailsPriceTables = ({
                   )?.name ?? priceTable,
               }
             })}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.removeFromOrg),
-                handleCallback: (rowParams: any) =>
-                  handleRemovePriceTables(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleRemovePriceTables)}
           />
         </div>
         <div>
@@ -143,19 +146,7 @@ const OrganizationDetailsPriceTables = ({
             fullWidth
             schema={getSchema('availablePriceTables')}
             items={priceTableOptions}
-            bulkActions={{
-              texts: {
-                rowsSelected: (qty: number) =>
-                  formatMessage(messages.selectedRows, {
-                    qty,
-                  }),
-              },
-              main: {
-                label: formatMessage(messages.addToOrg),
-                handleCallback: (rowParams: any) =>
-                  handleAddPriceTables(rowParams),
-              },
-            }}
+            bulkActions={bulkActions(handleAddPriceTables)}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsUsers.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsUsers.tsx
@@ -1,0 +1,34 @@
+import { PageBlock } from 'vtex.styleguide'
+import React, { Fragment } from 'react'
+import { useIntl } from 'react-intl'
+
+import OrganizationUsersTable from '../../components/OrganizationUsersTable'
+import { organizationMessages as messages } from '../utils/messages'
+
+const OrganizationDetailsUsers = ({
+  params,
+  loadingState,
+}: {
+  params: any
+  loadingState: any
+}) => {
+  /**
+   * Hooks
+   */
+  const { formatMessage } = useIntl()
+
+  return (
+    <Fragment>
+      <PageBlock title={formatMessage(messages.users)}>
+        <OrganizationUsersTable
+          organizationId={params?.id}
+          permissions={[]}
+          refetchCostCenters={loadingState}
+          isAdmin={true}
+        />
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsUsers

--- a/react/admin/OrganizationDetails/useHashRouter.ts
+++ b/react/admin/OrganizationDetails/useHashRouter.ts
@@ -3,9 +3,11 @@ import React, { useEffect, useRef, useState } from 'react'
 const useHashRouter = ({
   sessionKey,
   defaultPath,
+  routes,
 }: {
   sessionKey: string
   defaultPath: string
+  routes: string[]
 }) => {
   const [tab, setTab] = React.useState('')
   const [location, setLocation] = useState(null as any)
@@ -33,7 +35,9 @@ const useHashRouter = ({
 
   useEffect(() => {
     if (!routerRef?.current) return
-    if (routerRef.current?.history?.location.pathname === '/') {
+    const { pathname } = routerRef.current?.history?.location
+
+    if (pathname === '/' || !routes.includes(pathname.replace('/', ''))) {
       const sessionTab = sessionStorage.getItem(sessionKey)
 
       routerRef.current?.history?.push(

--- a/react/admin/OrganizationDetails/useHashRouter.ts
+++ b/react/admin/OrganizationDetails/useHashRouter.ts
@@ -1,8 +1,15 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
-const useHashRouter = ({ routerRef, sessionKey }: any) => {
+const useHashRouter = ({
+  sessionKey,
+  defaultPath,
+}: {
+  sessionKey: string
+  defaultPath: string
+}) => {
   const [tab, setTab] = React.useState('')
   const [location, setLocation] = useState(null as any)
+  const routerRef = useRef(null as any)
 
   const setupTab = (_tab: string) => {
     sessionStorage.setItem(sessionKey, _tab)
@@ -22,24 +29,25 @@ const useHashRouter = ({ routerRef, sessionKey }: any) => {
     if (!location) return
 
     setupTab(location.pathname.replace('/', ''))
-  }, [location])
+  }, [location?.pathname])
 
   useEffect(() => {
     if (!routerRef?.current) return
     if (routerRef.current?.history?.location.pathname === '/') {
-      const sessionTab = sessionStorage.getItem('organization-tab')
+      const sessionTab = sessionStorage.getItem(sessionKey)
 
       routerRef.current?.history?.push(
-        sessionTab ? `/${sessionTab}` : '/organizations'
+        sessionTab ? `/${sessionTab}` : `/${defaultPath}`
       )
     }
 
     setLocation(routerRef.current?.history?.location)
-  }, [routerRef])
+  }, [routerRef.current])
 
   return {
     tab,
     handleTabChange,
+    routerRef,
   }
 }
 

--- a/react/admin/OrganizationDetails/useHashRouter.ts
+++ b/react/admin/OrganizationDetails/useHashRouter.ts
@@ -27,11 +27,34 @@ const useHashRouter = ({
     setupTab(_tab)
   }
 
+  const onHashChange = () => {
+    const hash = window.location.hash.replace('#/', '')
+
+    if (routes.includes(hash)) {
+      setupTab(hash)
+    }
+  }
+
   useEffect(() => {
     if (!location) return
-
     setupTab(location.pathname.replace('/', ''))
   }, [location?.pathname])
+
+  useEffect(() => {
+    let lastHash = window.location.hash
+    const handleHashChange = () => {
+      if (lastHash !== window.location.hash) {
+        lastHash = window.location.hash
+        onHashChange()
+      }
+    }
+
+    const interval = setInterval(handleHashChange, 400)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
 
   useEffect(() => {
     if (!routerRef?.current) return

--- a/react/admin/OrganizationDetails/useHashRouter.ts
+++ b/react/admin/OrganizationDetails/useHashRouter.ts
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react'
+
+const useHashRouter = ({ routerRef, sessionKey }: any) => {
+  const [tab, setTab] = React.useState('')
+  const [location, setLocation] = useState(null as any)
+
+  const setupTab = (_tab: string) => {
+    sessionStorage.setItem(sessionKey, _tab)
+    setTab(_tab)
+  }
+
+  const handleTabChange = (_tab: string) => {
+    if (!routerRef?.current) {
+      return
+    }
+
+    routerRef.current?.history?.push(`/${_tab}`)
+    setupTab(_tab)
+  }
+
+  useEffect(() => {
+    if (!location) return
+
+    setupTab(location.pathname.replace('/', ''))
+  }, [location])
+
+  useEffect(() => {
+    if (!routerRef?.current) return
+    if (routerRef.current?.history?.location.pathname === '/') {
+      const sessionTab = sessionStorage.getItem('organization-tab')
+
+      routerRef.current?.history?.push(
+        sessionTab ? `/${sessionTab}` : '/organizations'
+      )
+    }
+
+    setLocation(routerRef.current?.history?.location)
+  }, [routerRef])
+
+  return {
+    tab,
+    handleTabChange,
+  }
+}
+
+export default useHashRouter

--- a/react/admin/OrganizationRequestDetails.tsx
+++ b/react/admin/OrganizationRequestDetails.tsx
@@ -106,7 +106,7 @@ const OrganizationRequestDetails: FunctionComponent = () => {
           linkLabel={formatMessage(messages.back)}
           onLinkClick={() => {
             navigate({
-              page: 'admin.app.b2b-organizations.organization-requests',
+              page: 'admin.app.b2b-organizations.organizations',
             })
           }}
         />

--- a/react/admin/OrganizationRequestsTable.tsx
+++ b/react/admin/OrganizationRequestsTable.tsx
@@ -1,14 +1,7 @@
 import type { FunctionComponent, ChangeEvent } from 'react'
-import React, { useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { useQuery } from 'react-apollo'
-import {
-  Layout,
-  PageHeader,
-  PageBlock,
-  Table,
-  Tag,
-  Checkbox,
-} from 'vtex.styleguide'
+import { Table, Tag, Checkbox } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
 
@@ -311,106 +304,101 @@ const OrganizationRequestsTable: FunctionComponent = () => {
   const { page, pageSize, search, sortedBy, sortOrder } = variableState
 
   return (
-    <Layout
-      fullWidth
-      pageHeader={<PageHeader title={formatMessage(messages.tablePageTitle)} />}
-    >
-      <PageBlock>
-        <Table
-          fullWidth
-          schema={getSchema()}
-          fixFirstColumn
-          loading={loading}
-          emptyStateLabel={formatMessage(messages.emptyState)}
-          items={data?.getOrganizationRequests?.data}
-          lineActions={lineActions}
-          onRowClick={({ rowData: { id } }: CellRendererProps) => {
-            if (!id) return
+    <Fragment>
+      <Table
+        fullWidth
+        schema={getSchema()}
+        fixFirstColumn
+        loading={loading}
+        emptyStateLabel={formatMessage(messages.emptyState)}
+        items={data?.getOrganizationRequests?.data}
+        lineActions={lineActions}
+        onRowClick={({ rowData: { id } }: CellRendererProps) => {
+          if (!id) return
 
-            navigate({
-              page: 'admin.app.b2b-organizations.organization-request-details',
-              params: { id },
-            })
-          }}
-          pagination={{
-            onNextClick: handleNextClick,
-            onPrevClick: handlePrevClick,
-            onRowsChange: handleRowsChange,
-            currentItemFrom: (page - 1) * pageSize + 1,
-            currentItemTo: total < page * pageSize ? total : page * pageSize,
-            textShowRows: formatMessage(messages.showRows),
-            textOf: formatMessage(messages.of),
-            totalItems: total ?? 0,
-            rowsOptions: [25, 50, 100],
-          }}
-          toolbar={{
-            inputSearch: {
-              value: search,
-              placeholder: formatMessage(messages.searchPlaceholder),
-              onChange: handleInputSearchChange,
-              onClear: handleInputSearchClear,
-              onSubmit: handleInputSearchSubmit,
-            },
-            // Hiding this because the dropdown renders off of the screen
-            // fields: {
-            //   label: '',
-            //   showAllLabel: '',
-            //   hideAllLabel: '',
-            // },
-          }}
-          sort={{
-            sortedBy,
-            sortOrder,
-          }}
-          onSort={handleSort}
-          filters={{
-            alwaysVisibleFilters: ['status'],
-            statements: filterState.filterStatements,
-            onChangeStatements: handleFiltersChange,
-            clearAllFiltersButtonLabel: formatMessage(messages.clearFilters),
-            collapseLeft: true,
-            options: {
-              status: {
-                label: formatMessage(messages.statusFilter),
-                renderFilterLabel: (st: any) => {
-                  if (!st || !st.object) {
-                    // you should treat empty object cases only for alwaysVisibleFilters
-                    return formatMessage(messages.filtersAll)
-                  }
+          navigate({
+            page: 'admin.app.b2b-organizations.organization-request-details',
+            params: { id },
+          })
+        }}
+        pagination={{
+          onNextClick: handleNextClick,
+          onPrevClick: handlePrevClick,
+          onRowsChange: handleRowsChange,
+          currentItemFrom: (page - 1) * pageSize + 1,
+          currentItemTo: total < page * pageSize ? total : page * pageSize,
+          textShowRows: formatMessage(messages.showRows),
+          textOf: formatMessage(messages.of),
+          totalItems: total ?? 0,
+          rowsOptions: [25, 50, 100],
+        }}
+        toolbar={{
+          inputSearch: {
+            value: search,
+            placeholder: formatMessage(messages.searchPlaceholder),
+            onChange: handleInputSearchChange,
+            onClear: handleInputSearchClear,
+            onSubmit: handleInputSearchSubmit,
+          },
+          // Hiding this because the dropdown renders off of the screen
+          // fields: {
+          //   label: '',
+          //   showAllLabel: '',
+          //   hideAllLabel: '',
+          // },
+        }}
+        sort={{
+          sortedBy,
+          sortOrder,
+        }}
+        onSort={handleSort}
+        filters={{
+          alwaysVisibleFilters: ['status'],
+          statements: filterState.filterStatements,
+          onChangeStatements: handleFiltersChange,
+          clearAllFiltersButtonLabel: formatMessage(messages.clearFilters),
+          collapseLeft: true,
+          options: {
+            status: {
+              label: formatMessage(messages.statusFilter),
+              renderFilterLabel: (st: any) => {
+                if (!st || !st.object) {
+                  // you should treat empty object cases only for alwaysVisibleFilters
+                  return formatMessage(messages.filtersAll)
+                }
 
-                  const keys = st.object ? Object.keys(st.object) : []
-                  const isAllTrue = !keys.some(key => !st.object[key])
-                  const isAllFalse = !keys.some(key => st.object[key])
-                  const trueKeys = keys.filter(key => st.object[key])
-                  let trueKeysLabel = ''
+                const keys = st.object ? Object.keys(st.object) : []
+                const isAllTrue = !keys.some(key => !st.object[key])
+                const isAllFalse = !keys.some(key => st.object[key])
+                const trueKeys = keys.filter(key => st.object[key])
+                let trueKeysLabel = ''
 
-                  trueKeys.forEach((key, index) => {
-                    trueKeysLabel += `${key}${
-                      index === trueKeys.length - 1 ? '' : ', '
-                    }`
-                  })
-
-                  return `${
-                    isAllTrue
-                      ? formatMessage(messages.filtersAll)
-                      : isAllFalse
-                      ? formatMessage(messages.filtersNone)
-                      : `${trueKeysLabel}`
+                trueKeys.forEach((key, index) => {
+                  trueKeysLabel += `${key}${
+                    index === trueKeys.length - 1 ? '' : ', '
                   }`
-                },
-                verbs: [
-                  {
-                    label: formatMessage(messages.filtersIncludes),
-                    value: 'includes',
-                    object: statusSelectorObject,
-                  },
-                ],
+                })
+
+                return `${
+                  isAllTrue
+                    ? formatMessage(messages.filtersAll)
+                    : isAllFalse
+                    ? formatMessage(messages.filtersNone)
+                    : `${trueKeysLabel}`
+                }`
               },
+              verbs: [
+                {
+                  label: formatMessage(messages.filtersIncludes),
+                  value: 'includes',
+                  object: statusSelectorObject,
+                },
+              ],
             },
-          }}
-        ></Table>
-      </PageBlock>
-    </Layout>
+          },
+        }}
+      />
+    </Fragment>
   )
 }
 

--- a/react/admin/OrganizationsList.tsx
+++ b/react/admin/OrganizationsList.tsx
@@ -1,0 +1,588 @@
+import type { FunctionComponent, ChangeEvent } from 'react'
+import React, { Fragment, useState } from 'react'
+import { useQuery, useMutation } from 'react-apollo'
+import { Table, Tag, Checkbox, Modal, Input, Button } from 'vtex.styleguide'
+import { useIntl, FormattedMessage } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
+import { useToast } from '@vtex/admin-ui'
+import {
+  AddressRules,
+  AddressForm,
+  AddressContainer,
+  CountrySelector,
+  PostalCodeGetter,
+} from 'vtex.address-form'
+import { StyleguideInput } from 'vtex.address-form/inputs'
+import { addValidation } from 'vtex.address-form/helpers'
+
+import { organizationMessages as messages } from './utils/messages'
+import { getEmptyAddress, isValidAddress } from '../utils/addresses'
+import GET_ORGANIZATIONS from '../graphql/getOrganizations.graphql'
+import GET_LOGISTICS from '../graphql/getLogistics.graphql'
+import CREATE_ORGANIZATION from '../graphql/createOrganization.graphql'
+
+interface CellRendererProps {
+  cellData: unknown
+  rowData: OrganizationSimple
+  updateCellMeasurements: () => void
+}
+
+interface OrganizationSimple {
+  id: string
+  name: string
+  status: string
+}
+
+export const labelTypeByStatusMap: Record<string, string> = {
+  active: 'success',
+  inactive: 'error',
+  'on-hold': 'warning',
+}
+
+const initialState = {
+  status: ['active', 'on-hold', 'inactive'],
+  search: '',
+  page: 1,
+  pageSize: 25,
+  sortOrder: 'ASC',
+  sortedBy: 'name',
+}
+
+const OrganizationsList: FunctionComponent = () => {
+  const { formatMessage } = useIntl()
+  const {
+    navigate,
+    culture: { country },
+  } = useRuntime()
+
+  const showToast = useToast()
+
+  const [filterState, setFilterState] = useState({
+    filterStatements: [] as FilterStatement[],
+  })
+
+  const [loadingState, setLoadingState] = useState(false)
+  const [variableState, setVariables] = useState(initialState)
+  const [newOrganizationModalState, setNewOrganizationModalState] = useState(
+    false
+  )
+
+  const [newOrganizationName, setNewOrganizationName] = useState('')
+  const [newCostCenterName, setNewCostCenterName] = useState('')
+  const [
+    newCostCenterBusinessDocument,
+    setNewCostCenterBusinessDocument,
+  ] = useState('')
+
+  const [newCostCenterAddressState, setNewCostCenterAddressState] = useState(
+    addValidation(getEmptyAddress(country))
+  )
+
+  const { data, loading, refetch } = useQuery(GET_ORGANIZATIONS, {
+    variables: initialState,
+    ssr: false,
+  })
+
+  const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
+  const [createOrganization] = useMutation(CREATE_ORGANIZATION)
+
+  const translateCountries = () => {
+    const { shipsTo = [] } = logisticsData?.logistics ?? {}
+
+    return shipsTo.map((code: string) => ({
+      label: formatMessage({ id: `country.${code}` }),
+      value: code,
+    }))
+  }
+
+  const handleAddNewOrganization = () => {
+    setLoadingState(true)
+    const newAddress = {
+      addressId: newCostCenterAddressState.addressId.value,
+      addressType: newCostCenterAddressState.addressType.value,
+      city: newCostCenterAddressState.city.value,
+      complement: newCostCenterAddressState.complement.value,
+      country: newCostCenterAddressState.country.value,
+      receiverName: newCostCenterAddressState.receiverName.value,
+      geoCoordinates: newCostCenterAddressState.geoCoordinates.value,
+      neighborhood: newCostCenterAddressState.neighborhood.value,
+      number: newCostCenterAddressState.number.value,
+      postalCode: newCostCenterAddressState.postalCode.value,
+      reference: newCostCenterAddressState.reference.value,
+      state: newCostCenterAddressState.state.value,
+      street: newCostCenterAddressState.street.value,
+      addressQuery: newCostCenterAddressState.addressQuery.value,
+    }
+
+    const variables = {
+      input: {
+        name: newOrganizationName,
+        defaultCostCenter: {
+          name: newCostCenterName,
+          address: newAddress,
+          businessDocument: newCostCenterBusinessDocument,
+        },
+      },
+    }
+
+    createOrganization({ variables })
+      .then(() => {
+        setNewOrganizationModalState(false)
+        setLoadingState(false)
+        setNewOrganizationName('')
+        setNewCostCenterName('')
+        setNewCostCenterBusinessDocument('')
+        setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
+        showToast({
+          type: 'success',
+          message: formatMessage(messages.toastAddOrgSuccess),
+        })
+        refetch(initialState)
+      })
+      .catch(error => {
+        setNewOrganizationModalState(false)
+        setLoadingState(false)
+        console.error(error)
+        showToast({
+          type: 'error',
+          message: formatMessage(messages.toastAddOrgFailure),
+        })
+      })
+  }
+
+  const handleNewCostCenterAddressChange = (
+    changedAddress: AddressFormFields
+  ) => {
+    const curAddress = newCostCenterAddressState
+
+    const newAddress = { ...curAddress, ...changedAddress }
+
+    setNewCostCenterAddressState(newAddress)
+  }
+
+  const handleCloseModal = () => {
+    setNewOrganizationModalState(false)
+    setNewOrganizationName('')
+    setNewCostCenterName('')
+    setNewCostCenterBusinessDocument('')
+    setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
+  }
+
+  const getSchema = () => ({
+    properties: {
+      name: {
+        title: formatMessage(messages.tableColumnName),
+      },
+      status: {
+        title: formatMessage(messages.columnStatus),
+        cellRenderer: ({ rowData: { status } }: CellRendererProps) => (
+          <Tag type={labelTypeByStatusMap[status]}>{status}</Tag>
+        ),
+        sortable: true,
+      },
+    },
+  })
+
+  const statusSelectorObject = ({
+    value,
+    onChange,
+  }: {
+    value: Record<string, unknown>
+    onChange: any
+  }) => {
+    const initialValue = {
+      active: true,
+      'on-hold': true,
+      inactive: true,
+      ...(value || {}),
+    } as Record<string, unknown>
+
+    const toggleValueByKey = (key: string) => {
+      const newValue = {
+        ...(value || initialValue),
+        [key]: value ? !value[key] : false,
+      }
+
+      return newValue
+    }
+
+    return (
+      <div>
+        {Object.keys(initialValue).map((opt, index) => {
+          return (
+            <div className="mb3" key={`status-select-object-${opt}-${index}`}>
+              <Checkbox
+                checked={value ? value[opt] : initialValue[opt]}
+                label={opt}
+                name="status-checkbox-group"
+                onChange={() => {
+                  const newValue = toggleValueByKey(`${opt}`)
+                  const newValueKeys = Object.keys(newValue)
+                  const isEmptyFilter = !newValueKeys.some(
+                    key => !newValue[key]
+                  )
+
+                  onChange(isEmptyFilter ? null : newValue)
+                }}
+                value={opt}
+              />
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  const handlePrevClick = () => {
+    if (variableState.page === 1) return
+
+    const newPage = variableState.page - 1
+
+    setVariables({
+      ...variableState,
+      page: newPage,
+    })
+
+    refetch({
+      ...variableState,
+      page: newPage,
+    })
+  }
+
+  const handleNextClick = () => {
+    const newPage = variableState.page + 1
+
+    setVariables({
+      ...variableState,
+      page: newPage,
+    })
+
+    refetch({
+      ...variableState,
+      page: newPage,
+    })
+  }
+
+  const handleRowsChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value },
+    } = e
+
+    setVariables({
+      ...variableState,
+      page: 1,
+      pageSize: +value,
+    })
+
+    refetch({
+      ...variableState,
+      page: 1,
+      pageSize: +value,
+    })
+  }
+
+  const handleFiltersChange = (statements: FilterStatement[]) => {
+    const statuses = [] as string[]
+
+    statements.forEach(statement => {
+      if (!statement?.object) return
+      const { subject, object } = statement
+
+      switch (subject) {
+        case 'status': {
+          if (!object) return
+          const keys = Object.keys(object)
+          const isAllTrue = !keys.some(key => !object[key])
+          const isAllFalse = !keys.some(key => object[key])
+          const trueKeys = keys.filter(key => object[key])
+
+          if (isAllTrue) break
+          if (isAllFalse) statuses.push('none')
+          statuses.push(...trueKeys)
+          break
+        }
+
+        default:
+          break
+      }
+    })
+
+    setFilterState({
+      filterStatements: statements,
+    })
+
+    setVariables({
+      ...variableState,
+      status: statuses,
+      page: 1,
+    })
+
+    refetch({
+      ...variableState,
+      page: 1,
+      status: statuses,
+    })
+  }
+
+  const handleInputSearchChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const {
+      currentTarget: { value },
+    } = e
+
+    setVariables({
+      ...variableState,
+      search: value,
+    })
+  }
+
+  const handleInputSearchClear = () => {
+    setVariables({
+      ...variableState,
+      search: '',
+    })
+
+    refetch({
+      ...variableState,
+      search: '',
+      page: 1,
+    })
+  }
+
+  const handleInputSearchSubmit = () => {
+    refetch({
+      ...variableState,
+      page: 1,
+    })
+  }
+
+  const handleSort = ({
+    sortOrder,
+    sortedBy,
+  }: {
+    sortOrder: string
+    sortedBy: string
+  }) => {
+    setVariables({
+      ...variableState,
+      sortOrder,
+      sortedBy,
+    })
+    refetch({
+      ...variableState,
+      page: 1,
+      sortOrder,
+      sortedBy,
+    })
+  }
+
+  const lineActions = [
+    {
+      label: () => formatMessage(messages.view),
+      onClick: ({ rowData: { id } }: CellRendererProps) => {
+        if (!id) return
+
+        navigate({
+          page: 'admin.app.b2b-organizations.organization-details',
+          params: { id },
+        })
+      },
+    },
+  ]
+
+  const { total } = data?.getOrganizations?.pagination ?? 0
+  const { page, pageSize, search, sortedBy, sortOrder } = variableState
+
+  return (
+    <Fragment>
+      <Table
+        fullWidth
+        schema={getSchema()}
+        fixFirstColumn
+        loading={loading}
+        emptyStateLabel={formatMessage(messages.organizationsEmptyState)}
+        items={data?.getOrganizations?.data}
+        lineActions={lineActions}
+        onRowClick={({ rowData: { id } }: CellRendererProps) => {
+          if (!id) return
+
+          navigate({
+            page: 'admin.app.b2b-organizations.organization-details',
+            params: { id },
+          })
+        }}
+        pagination={{
+          onNextClick: handleNextClick,
+          onPrevClick: handlePrevClick,
+          onRowsChange: handleRowsChange,
+          currentItemFrom: (page - 1) * pageSize + 1,
+          currentItemTo: total < page * pageSize ? total : page * pageSize,
+          textShowRows: formatMessage(messages.showRows),
+          textOf: formatMessage(messages.of),
+          totalItems: total ?? 0,
+          rowsOptions: [25, 50, 100],
+        }}
+        toolbar={{
+          inputSearch: {
+            value: search,
+            placeholder: formatMessage(messages.searchPlaceholder),
+            onChange: handleInputSearchChange,
+            onClear: handleInputSearchClear,
+            onSubmit: handleInputSearchSubmit,
+          },
+          newLine: {
+            label: formatMessage(messages.new),
+            handleCallback: () => setNewOrganizationModalState(true),
+          },
+        }}
+        sort={{
+          sortedBy,
+          sortOrder,
+        }}
+        onSort={handleSort}
+        filters={{
+          alwaysVisibleFilters: ['status'],
+          statements: filterState.filterStatements,
+          onChangeStatements: handleFiltersChange,
+          clearAllFiltersButtonLabel: formatMessage(messages.clearFilters),
+          collapseLeft: true,
+          options: {
+            status: {
+              label: formatMessage(messages.filterStatus),
+              renderFilterLabel: (st: any) => {
+                if (!st || !st.object) {
+                  // you should treat empty object cases only for alwaysVisibleFilters
+                  return formatMessage(messages.filtersAll)
+                }
+
+                const keys = st.object ? Object.keys(st.object) : []
+                const isAllTrue = !keys.some(key => !st.object[key])
+                const isAllFalse = !keys.some(key => st.object[key])
+                const trueKeys = keys.filter(key => st.object[key])
+                let trueKeysLabel = ''
+
+                trueKeys.forEach((key, index) => {
+                  trueKeysLabel += `${key}${
+                    index === trueKeys.length - 1 ? '' : ', '
+                  }`
+                })
+
+                return `${
+                  isAllTrue
+                    ? formatMessage(messages.filtersAll)
+                    : isAllFalse
+                    ? formatMessage(messages.filtersNone)
+                    : `${trueKeysLabel}`
+                }`
+              },
+              verbs: [
+                {
+                  label: formatMessage(messages.filtersIncludes),
+                  value: 'includes',
+                  object: statusSelectorObject,
+                },
+              ],
+            },
+          },
+        }}
+      />
+
+      <Modal
+        centered
+        bottomBar={
+          <div className="nowrap">
+            <span className="mr4">
+              <Button
+                variation="tertiary"
+                onClick={() => handleCloseModal()}
+                disabled={loadingState}
+              >
+                {formatMessage(messages.cancel)}
+              </Button>
+            </span>
+            <span>
+              <Button
+                variation="primary"
+                onClick={() => handleAddNewOrganization()}
+                isLoading={loadingState}
+                disabled={
+                  !newOrganizationName ||
+                  !newCostCenterName ||
+                  !isValidAddress(newCostCenterAddressState)
+                }
+              >
+                {formatMessage(messages.add)}
+              </Button>
+            </span>
+          </div>
+        }
+        isOpen={newOrganizationModalState}
+        onClose={() => handleCloseModal()}
+        closeOnOverlayClick={false}
+      >
+        <p className="f3 f1-ns fw3 gray">
+          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization" />
+        </p>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.organizationName)}
+            value={newOrganizationName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewOrganizationName(e.target.value)
+            }}
+            required
+          />
+        </div>
+        <div className="w-100 mv6">
+          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization.default-costCenter.helpText" />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.defaultCostCenterName)}
+            value={newCostCenterName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterName(e.target.value)
+            }}
+            required
+          />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.businessDocument)}
+            value={newCostCenterBusinessDocument}
+            helpText={formatMessage(messages.businessDocumentHelp)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterBusinessDocument(e.target.value)
+            }}
+          />
+        </div>
+        <AddressRules
+          country={newCostCenterAddressState?.country?.value}
+          shouldUseIOFetching
+          useGeolocation={false}
+        >
+          <AddressContainer
+            address={newCostCenterAddressState}
+            Input={StyleguideInput}
+            onChangeAddress={handleNewCostCenterAddressChange}
+            autoCompletePostalCode
+          >
+            <CountrySelector shipsTo={translateCountries()} />
+
+            <PostalCodeGetter />
+
+            <AddressForm
+              Input={StyleguideInput}
+              omitAutoCompletedFields={false}
+              omitPostalCodeFields
+            />
+          </AddressContainer>
+        </AddressRules>
+      </Modal>
+    </Fragment>
+  )
+}
+
+export default OrganizationsList

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import { PageHeader, PageBlock, Layout, Tabs, Tab } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
 import { HashRouter, Switch, Route } from 'react-router-dom'
@@ -21,10 +21,9 @@ const Container = ({ children }: any) => (
 
 const OrganizationsTable = () => {
   const { formatMessage } = useIntl()
-  const routerRef = useRef(null)
-  const { tab, handleTabChange } = useHashRouter({
-    routerRef,
+  const { tab, handleTabChange, routerRef } = useHashRouter({
     sessionKey: SESSION_STORAGE_KEY,
+    defaultPath: 'organizations',
   })
 
   return (

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import { PageHeader, PageBlock, Layout, Tabs, Tab } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
 import { HashRouter, Switch, Route } from 'react-router-dom'
@@ -9,6 +9,7 @@ import {
 } from './utils/messages'
 import OrganizationsList from './OrganizationsList'
 import OrganizationRequestsTable from './OrganizationRequestsTable'
+import useHashRouter from './OrganizationDetails/useHashRouter'
 
 const SESSION_STORAGE_KEY = 'organization-tab'
 
@@ -20,42 +21,11 @@ const Container = ({ children }: any) => (
 
 const OrganizationsTable = () => {
   const { formatMessage } = useIntl()
-  const [tab, setTab] = React.useState('organizations')
-  const routerRef = useRef(null as any)
-  const [location, setLocation] = useState(null as any)
-
-  const setupTab = (_tab: string) => {
-    sessionStorage.setItem(SESSION_STORAGE_KEY, _tab)
-    setTab(_tab)
-  }
-
-  const handleTabChange = (_tab: string) => {
-    if (!routerRef?.current) {
-      return
-    }
-
-    routerRef.current?.history?.push(`/${_tab}`)
-    setupTab(_tab)
-  }
-
-  useEffect(() => {
-    if (!location) return
-
-    setupTab(location.pathname.replace('/', ''))
-  }, [location])
-
-  useEffect(() => {
-    if (!routerRef?.current) return
-    if (routerRef.current?.history?.location.pathname === '/') {
-      const sessionTab = sessionStorage.getItem('organization-tab')
-
-      routerRef.current?.history?.push(
-        sessionTab ? `/${sessionTab}` : '/organizations'
-      )
-    }
-
-    setLocation(routerRef.current?.history?.location)
-  }, [routerRef])
+  const routerRef = useRef(null)
+  const { tab, handleTabChange } = useHashRouter({
+    routerRef,
+    sessionKey: SESSION_STORAGE_KEY,
+  })
 
   return (
     <Layout

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -24,6 +24,7 @@ const OrganizationsTable = () => {
   const { tab, handleTabChange, routerRef } = useHashRouter({
     sessionKey: SESSION_STORAGE_KEY,
     defaultPath: 'organizations',
+    routes: ['organizations', 'requests'],
   })
 
   return (

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -1,606 +1,91 @@
-import type { FunctionComponent, ChangeEvent } from 'react'
-import React, { useState } from 'react'
-import { useQuery, useMutation } from 'react-apollo'
+import React, { useEffect, useRef, useState } from 'react'
+import { PageHeader, PageBlock, Layout, Tabs, Tab } from 'vtex.styleguide'
+import { useIntl } from 'react-intl'
+import { HashRouter, Switch, Route } from 'react-router-dom'
+
 import {
-  Layout,
-  PageHeader,
-  PageBlock,
-  Table,
-  Tag,
-  Checkbox,
-  Modal,
-  Input,
-  Button,
-} from 'vtex.styleguide'
-import { useIntl, FormattedMessage } from 'react-intl'
-import { useRuntime } from 'vtex.render-runtime'
-import { useToast } from '@vtex/admin-ui'
-import {
-  AddressRules,
-  AddressForm,
-  AddressContainer,
-  CountrySelector,
-  PostalCodeGetter,
-} from 'vtex.address-form'
-import { StyleguideInput } from 'vtex.address-form/inputs'
-import { addValidation } from 'vtex.address-form/helpers'
+  organizationMessages as messages,
+  organizationRequestMessages as requestMessages,
+} from './utils/messages'
+import OrganizationsList from './OrganizationsList'
+import OrganizationRequestsTable from './OrganizationRequestsTable'
 
-import { organizationMessages as messages } from './utils/messages'
-import { getEmptyAddress, isValidAddress } from '../utils/addresses'
-import GET_ORGANIZATIONS from '../graphql/getOrganizations.graphql'
-import GET_LOGISTICS from '../graphql/getLogistics.graphql'
-import CREATE_ORGANIZATION from '../graphql/createOrganization.graphql'
+const SESSION_STORAGE_KEY = 'organization-tab'
 
-interface CellRendererProps {
-  cellData: unknown
-  rowData: OrganizationSimple
-  updateCellMeasurements: () => void
-}
+const Container = ({ children }: any) => (
+  <div className="mt6">
+    <PageBlock>{children}</PageBlock>
+  </div>
+)
 
-interface OrganizationSimple {
-  id: string
-  name: string
-  status: string
-}
-
-export const labelTypeByStatusMap: Record<string, string> = {
-  active: 'success',
-  inactive: 'error',
-  'on-hold': 'warning',
-}
-
-const initialState = {
-  status: ['active', 'on-hold', 'inactive'],
-  search: '',
-  page: 1,
-  pageSize: 25,
-  sortOrder: 'ASC',
-  sortedBy: 'name',
-}
-
-const OrganizationsTable: FunctionComponent = () => {
+const OrganizationsTable = () => {
   const { formatMessage } = useIntl()
-  const {
-    navigate,
-    culture: { country },
-  } = useRuntime()
+  const [tab, setTab] = React.useState('organizations')
+  const routerRef = useRef(null as any)
+  const [location, setLocation] = useState(null as any)
 
-  const showToast = useToast()
-
-  const [filterState, setFilterState] = useState({
-    filterStatements: [] as FilterStatement[],
-  })
-
-  const [loadingState, setLoadingState] = useState(false)
-  const [variableState, setVariables] = useState(initialState)
-  const [newOrganizationModalState, setNewOrganizationModalState] = useState(
-    false
-  )
-
-  const [newOrganizationName, setNewOrganizationName] = useState('')
-  const [newCostCenterName, setNewCostCenterName] = useState('')
-  const [
-    newCostCenterBusinessDocument,
-    setNewCostCenterBusinessDocument,
-  ] = useState('')
-
-  const [newCostCenterAddressState, setNewCostCenterAddressState] = useState(
-    addValidation(getEmptyAddress(country))
-  )
-
-  const { data, loading, refetch } = useQuery(GET_ORGANIZATIONS, {
-    variables: initialState,
-    ssr: false,
-  })
-
-  const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
-  const [createOrganization] = useMutation(CREATE_ORGANIZATION)
-
-  const translateCountries = () => {
-    const { shipsTo = [] } = logisticsData?.logistics ?? {}
-
-    return shipsTo.map((code: string) => ({
-      label: formatMessage({ id: `country.${code}` }),
-      value: code,
-    }))
+  const setupTab = (_tab: string) => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, _tab)
+    setTab(_tab)
   }
 
-  const handleAddNewOrganization = () => {
-    setLoadingState(true)
-    const newAddress = {
-      addressId: newCostCenterAddressState.addressId.value,
-      addressType: newCostCenterAddressState.addressType.value,
-      city: newCostCenterAddressState.city.value,
-      complement: newCostCenterAddressState.complement.value,
-      country: newCostCenterAddressState.country.value,
-      receiverName: newCostCenterAddressState.receiverName.value,
-      geoCoordinates: newCostCenterAddressState.geoCoordinates.value,
-      neighborhood: newCostCenterAddressState.neighborhood.value,
-      number: newCostCenterAddressState.number.value,
-      postalCode: newCostCenterAddressState.postalCode.value,
-      reference: newCostCenterAddressState.reference.value,
-      state: newCostCenterAddressState.state.value,
-      street: newCostCenterAddressState.street.value,
-      addressQuery: newCostCenterAddressState.addressQuery.value,
+  const handleTabChange = (_tab: string) => {
+    if (!routerRef?.current) {
+      return
     }
 
-    const variables = {
-      input: {
-        name: newOrganizationName,
-        defaultCostCenter: {
-          name: newCostCenterName,
-          address: newAddress,
-          businessDocument: newCostCenterBusinessDocument,
-        },
-      },
+    routerRef.current?.history?.push(`/${_tab}`)
+    setupTab(_tab)
+  }
+
+  useEffect(() => {
+    if (!location) return
+
+    setupTab(location.pathname.replace('/', ''))
+  }, [location])
+
+  useEffect(() => {
+    if (!routerRef?.current) return
+    if (routerRef.current?.history?.location.pathname === '/') {
+      const sessionTab = sessionStorage.getItem('organization-tab')
+
+      routerRef.current?.history?.push(
+        sessionTab ? `/${sessionTab}` : '/organizations'
+      )
     }
 
-    createOrganization({ variables })
-      .then(() => {
-        setNewOrganizationModalState(false)
-        setLoadingState(false)
-        setNewOrganizationName('')
-        setNewCostCenterName('')
-        setNewCostCenterBusinessDocument('')
-        setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
-        showToast({
-          type: 'success',
-          message: formatMessage(messages.toastAddOrgSuccess),
-        })
-        refetch(initialState)
-      })
-      .catch(error => {
-        setNewOrganizationModalState(false)
-        setLoadingState(false)
-        console.error(error)
-        showToast({
-          type: 'error',
-          message: formatMessage(messages.toastAddOrgFailure),
-        })
-      })
-  }
-
-  const handleNewCostCenterAddressChange = (
-    changedAddress: AddressFormFields
-  ) => {
-    const curAddress = newCostCenterAddressState
-
-    const newAddress = { ...curAddress, ...changedAddress }
-
-    setNewCostCenterAddressState(newAddress)
-  }
-
-  const handleCloseModal = () => {
-    setNewOrganizationModalState(false)
-    setNewOrganizationName('')
-    setNewCostCenterName('')
-    setNewCostCenterBusinessDocument('')
-    setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
-  }
-
-  const getSchema = () => ({
-    properties: {
-      name: {
-        title: formatMessage(messages.tableColumnName),
-      },
-      status: {
-        title: formatMessage(messages.columnStatus),
-        cellRenderer: ({ rowData: { status } }: CellRendererProps) => (
-          <Tag type={labelTypeByStatusMap[status]}>{status}</Tag>
-        ),
-        sortable: true,
-      },
-    },
-  })
-
-  const statusSelectorObject = ({
-    value,
-    onChange,
-  }: {
-    value: Record<string, unknown>
-    onChange: any
-  }) => {
-    const initialValue = {
-      active: true,
-      'on-hold': true,
-      inactive: true,
-      ...(value || {}),
-    } as Record<string, unknown>
-
-    const toggleValueByKey = (key: string) => {
-      const newValue = {
-        ...(value || initialValue),
-        [key]: value ? !value[key] : false,
-      }
-
-      return newValue
-    }
-
-    return (
-      <div>
-        {Object.keys(initialValue).map((opt, index) => {
-          return (
-            <div className="mb3" key={`status-select-object-${opt}-${index}`}>
-              <Checkbox
-                checked={value ? value[opt] : initialValue[opt]}
-                label={opt}
-                name="status-checkbox-group"
-                onChange={() => {
-                  const newValue = toggleValueByKey(`${opt}`)
-                  const newValueKeys = Object.keys(newValue)
-                  const isEmptyFilter = !newValueKeys.some(
-                    key => !newValue[key]
-                  )
-
-                  onChange(isEmptyFilter ? null : newValue)
-                }}
-                value={opt}
-              />
-            </div>
-          )
-        })}
-      </div>
-    )
-  }
-
-  const handlePrevClick = () => {
-    if (variableState.page === 1) return
-
-    const newPage = variableState.page - 1
-
-    setVariables({
-      ...variableState,
-      page: newPage,
-    })
-
-    refetch({
-      ...variableState,
-      page: newPage,
-    })
-  }
-
-  const handleNextClick = () => {
-    const newPage = variableState.page + 1
-
-    setVariables({
-      ...variableState,
-      page: newPage,
-    })
-
-    refetch({
-      ...variableState,
-      page: newPage,
-    })
-  }
-
-  const handleRowsChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const {
-      target: { value },
-    } = e
-
-    setVariables({
-      ...variableState,
-      page: 1,
-      pageSize: +value,
-    })
-
-    refetch({
-      ...variableState,
-      page: 1,
-      pageSize: +value,
-    })
-  }
-
-  const handleFiltersChange = (statements: FilterStatement[]) => {
-    const statuses = [] as string[]
-
-    statements.forEach(statement => {
-      if (!statement?.object) return
-      const { subject, object } = statement
-
-      switch (subject) {
-        case 'status': {
-          if (!object) return
-          const keys = Object.keys(object)
-          const isAllTrue = !keys.some(key => !object[key])
-          const isAllFalse = !keys.some(key => object[key])
-          const trueKeys = keys.filter(key => object[key])
-
-          if (isAllTrue) break
-          if (isAllFalse) statuses.push('none')
-          statuses.push(...trueKeys)
-          break
-        }
-
-        default:
-          break
-      }
-    })
-
-    setFilterState({
-      filterStatements: statements,
-    })
-
-    setVariables({
-      ...variableState,
-      status: statuses,
-      page: 1,
-    })
-
-    refetch({
-      ...variableState,
-      page: 1,
-      status: statuses,
-    })
-  }
-
-  const handleInputSearchChange = (e: React.FormEvent<HTMLInputElement>) => {
-    const {
-      currentTarget: { value },
-    } = e
-
-    setVariables({
-      ...variableState,
-      search: value,
-    })
-  }
-
-  const handleInputSearchClear = () => {
-    setVariables({
-      ...variableState,
-      search: '',
-    })
-
-    refetch({
-      ...variableState,
-      search: '',
-      page: 1,
-    })
-  }
-
-  const handleInputSearchSubmit = () => {
-    refetch({
-      ...variableState,
-      page: 1,
-    })
-  }
-
-  const handleSort = ({
-    sortOrder,
-    sortedBy,
-  }: {
-    sortOrder: string
-    sortedBy: string
-  }) => {
-    setVariables({
-      ...variableState,
-      sortOrder,
-      sortedBy,
-    })
-    refetch({
-      ...variableState,
-      page: 1,
-      sortOrder,
-      sortedBy,
-    })
-  }
-
-  const lineActions = [
-    {
-      label: () => formatMessage(messages.view),
-      onClick: ({ rowData: { id } }: CellRendererProps) => {
-        if (!id) return
-
-        navigate({
-          page: 'admin.app.b2b-organizations.organization-details',
-          params: { id },
-        })
-      },
-    },
-  ]
-
-  const { total } = data?.getOrganizations?.pagination ?? 0
-  const { page, pageSize, search, sortedBy, sortOrder } = variableState
+    setLocation(routerRef.current?.history?.location)
+  }, [routerRef])
 
   return (
     <Layout
       fullWidth
-      pageHeader={
-        <PageHeader title={formatMessage(messages.tablePageTitle)}>
-          <Button onClick={() => refetch()}>
-            <FormattedMessage id="admin/b2b-organizations.organizations-admin.button.refetch" />
-          </Button>
-        </PageHeader>
-      }
+      pageHeader={<PageHeader title={formatMessage(messages.tablePageTitle)} />}
     >
-      <PageBlock>
-        <Table
-          fullWidth
-          schema={getSchema()}
-          fixFirstColumn
-          loading={loading}
-          emptyStateLabel={formatMessage(messages.organizationsEmptyState)}
-          items={data?.getOrganizations?.data}
-          lineActions={lineActions}
-          onRowClick={({ rowData: { id } }: CellRendererProps) => {
-            if (!id) return
-
-            navigate({
-              page: 'admin.app.b2b-organizations.organization-details',
-              params: { id },
-            })
-          }}
-          pagination={{
-            onNextClick: handleNextClick,
-            onPrevClick: handlePrevClick,
-            onRowsChange: handleRowsChange,
-            currentItemFrom: (page - 1) * pageSize + 1,
-            currentItemTo: total < page * pageSize ? total : page * pageSize,
-            textShowRows: formatMessage(messages.showRows),
-            textOf: formatMessage(messages.of),
-            totalItems: total ?? 0,
-            rowsOptions: [25, 50, 100],
-          }}
-          toolbar={{
-            inputSearch: {
-              value: search,
-              placeholder: formatMessage(messages.searchPlaceholder),
-              onChange: handleInputSearchChange,
-              onClear: handleInputSearchClear,
-              onSubmit: handleInputSearchSubmit,
-            },
-            newLine: {
-              label: formatMessage(messages.new),
-              handleCallback: () => setNewOrganizationModalState(true),
-            },
-          }}
-          sort={{
-            sortedBy,
-            sortOrder,
-          }}
-          onSort={handleSort}
-          filters={{
-            alwaysVisibleFilters: ['status'],
-            statements: filterState.filterStatements,
-            onChangeStatements: handleFiltersChange,
-            clearAllFiltersButtonLabel: formatMessage(messages.clearFilters),
-            collapseLeft: true,
-            options: {
-              status: {
-                label: formatMessage(messages.filterStatus),
-                renderFilterLabel: (st: any) => {
-                  if (!st || !st.object) {
-                    // you should treat empty object cases only for alwaysVisibleFilters
-                    return formatMessage(messages.filtersAll)
-                  }
-
-                  const keys = st.object ? Object.keys(st.object) : []
-                  const isAllTrue = !keys.some(key => !st.object[key])
-                  const isAllFalse = !keys.some(key => st.object[key])
-                  const trueKeys = keys.filter(key => st.object[key])
-                  let trueKeysLabel = ''
-
-                  trueKeys.forEach((key, index) => {
-                    trueKeysLabel += `${key}${
-                      index === trueKeys.length - 1 ? '' : ', '
-                    }`
-                  })
-
-                  return `${
-                    isAllTrue
-                      ? formatMessage(messages.filtersAll)
-                      : isAllFalse
-                      ? formatMessage(messages.filtersNone)
-                      : `${trueKeysLabel}`
-                  }`
-                },
-                verbs: [
-                  {
-                    label: formatMessage(messages.filtersIncludes),
-                    value: 'includes',
-                    object: statusSelectorObject,
-                  },
-                ],
-              },
-            },
-          }}
-        ></Table>
-      </PageBlock>
-      <Modal
-        centered
-        bottomBar={
-          <div className="nowrap">
-            <span className="mr4">
-              <Button
-                variation="tertiary"
-                onClick={() => handleCloseModal()}
-                disabled={loadingState}
-              >
-                {formatMessage(messages.cancel)}
-              </Button>
-            </span>
-            <span>
-              <Button
-                variation="primary"
-                onClick={() => handleAddNewOrganization()}
-                isLoading={loadingState}
-                disabled={
-                  !newOrganizationName ||
-                  !newCostCenterName ||
-                  !isValidAddress(newCostCenterAddressState)
-                }
-              >
-                {formatMessage(messages.add)}
-              </Button>
-            </span>
-          </div>
-        }
-        isOpen={newOrganizationModalState}
-        onClose={() => handleCloseModal()}
-        closeOnOverlayClick={false}
-      >
-        <p className="f3 f1-ns fw3 gray">
-          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization" />
-        </p>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.organizationName)}
-            value={newOrganizationName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewOrganizationName(e.target.value)
-            }}
-            required
+      <HashRouter ref={routerRef}>
+        <Tabs>
+          <Tab
+            label={formatMessage(messages.tablePageTitle)}
+            active={tab === 'organizations'}
+            onClick={() => handleTabChange('organizations')}
           />
-        </div>
-        <div className="w-100 mv6">
-          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization.default-costCenter.helpText" />
-        </div>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.defaultCostCenterName)}
-            value={newCostCenterName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterName(e.target.value)
-            }}
-            required
+          <Tab
+            label={formatMessage(requestMessages.tablePageTitle)}
+            active={tab === 'requests'}
+            onClick={() => handleTabChange('requests')}
           />
-        </div>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.businessDocument)}
-            value={newCostCenterBusinessDocument}
-            helpText={formatMessage(messages.businessDocumentHelp)}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterBusinessDocument(e.target.value)
-            }}
-          />
-        </div>
-        <AddressRules
-          country={newCostCenterAddressState?.country?.value}
-          shouldUseIOFetching
-          useGeolocation={false}
-        >
-          <AddressContainer
-            address={newCostCenterAddressState}
-            Input={StyleguideInput}
-            onChangeAddress={handleNewCostCenterAddressChange}
-            autoCompletePostalCode
-          >
-            <CountrySelector shipsTo={translateCountries()} />
-
-            <PostalCodeGetter />
-
-            <AddressForm
-              Input={StyleguideInput}
-              omitAutoCompletedFields={false}
-              omitPostalCodeFields
+        </Tabs>
+        <Container>
+          <Switch>
+            <Route path="/organizations" exact component={OrganizationsList} />
+            <Route
+              path="/requests"
+              exact
+              component={OrganizationRequestsTable}
             />
-          </AddressContainer>
-        </AddressRules>
-      </Modal>
+          </Switch>
+        </Container>
+      </HashRouter>
     </Layout>
   )
 }

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -96,6 +96,9 @@ export const organizationMessages = defineMessages({
   removeUser: {
     id: `${adminPrefix}organization-details.button.remove-user`,
   },
+  default: {
+    id: `${adminPrefix}organization-details.default`,
+  },
   email: {
     id: `${adminPrefix}user-details.email`,
   },

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -99,6 +99,9 @@ export const organizationMessages = defineMessages({
   default: {
     id: `${adminPrefix}organization-details.default`,
   },
+  organizationNameRequired: {
+    id: `${adminPrefix}organization-details.organization-name-required`,
+  },
   email: {
     id: `${adminPrefix}user-details.email`,
   },

--- a/react/package.json
+++ b/react/package.json
@@ -11,6 +11,8 @@
     "@types/jest": "^25.1.4",
     "@types/node": "^13.9.8",
     "@types/react": "^16.9.31",
+    "@types/react-router": "^5.1.11",
+    "@types/react-router-dom": "^5.1.11",
     "@vtex/test-tools": "^3.3.2",
     "@vtex/tsconfig": "^0.6.0",
     "apollo-cache-inmemory": "^1.6.5",
@@ -34,6 +36,8 @@
     "apollo-client": "^2.6.10",
     "react": "^16.9.2",
     "react-apollo": "^3.1.5",
-    "react-intl": "^5.13.4"
+    "react-intl": "^5.13.4",
+    "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -998,6 +998,13 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
@@ -1553,6 +1560,11 @@
   dependencies:
     graphql "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1646,6 +1658,23 @@
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/react-router-dom@^5.1.11":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*", "@types/react-router@^5.1.11":
+  version "5.1.18"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.18.tgz#c8851884b60bc23733500d86c1266e1cfbbd9ef3"
+  integrity sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
 
 "@types/react-test-renderer@*":
   version "17.0.1"
@@ -3152,7 +3181,19 @@ hey-listen@^1.0.5, hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -3399,6 +3440,11 @@ is-wsl@^2.1.1:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0:
   version "1.0.0"
@@ -4076,7 +4122,7 @@ lolex@^5.0.0:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4167,6 +4213,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -4459,6 +4513,13 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -4654,7 +4715,7 @@ react-intl@^5.13.4:
     intl-messageformat "9.9.4"
     tslib "^2.1.0"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -4663,6 +4724,35 @@ react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-router-dom@^5.1.2:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.1.tgz#0151baf2365c5fcd8493f6ec9b9b31f34d0f8ae1"
+  integrity sha512-f0pj/gMAbv9e8gahTmCEY20oFhxhrmHwYeIwH5EO5xu0qme+wXtsdB8YfUOAZzUz4VaXmb58m3ceiLtjMhqYmQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.3.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.3.1, react-router@^5.1.2:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.1.tgz#b13e84a016c79b9e80dde123ca4112c4f117e3cf"
+  integrity sha512-v+zwjqb7bakqgF+wMVKlAPTca/cEmPOvQ9zt7gpSNyPXau1+0qvuYZ5BWzzNDP1y6s15zDwgb9rPN63+SIniRQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-side-effect@^2.1.0:
   version "2.1.1"
@@ -4894,6 +4984,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -5326,12 +5421,17 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
+tiny-invariant@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
 tiny-invariant@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
-tiny-warning@^1.0.3:
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -5559,6 +5659,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
# Summary
[Reference the B2B UX epic ticket](https://vtex-dev.atlassian.net/browse/USAAPPTEAM-531) for the full summary, reports, shared google drive, and detailed mockups related to these UX improvements.

## Organization Screen

Move the organization management into a single screen with 2 separate tabs for approved organizations and organization requests

Keep the same URLs when the tabs are loaded

This ticket is ONLY for adding the tabs UI. Any other changes displayed in the mockup will need separate Jira tickets

![image](https://user-images.githubusercontent.com/5812946/168285782-e78ce6ec-980e-4d3f-b57e-c435129594c8.png)

### Result

<img width="1841" alt="image" src="https://user-images.githubusercontent.com/5812946/168285181-7dece84f-c46a-4159-a759-0856c40c794a.png">


## Organization Details

Create separate tabs for displaying the various data required for setting up and managing an Organization
The current tabs for the Organization detail page will be:

- Details
- Cost Centers
- Collections
- Payment Terms
- Price Tables

Using tabs will reduce the need for scrolling by only loading the UI for the selected section
These mockups are for reference only, so initially, we will stick with the current data for the page
Adding new tabs such as users and pending quotes will require more discussion and new Jira tickets. You can ignore this information for now in the design example.

![image](https://user-images.githubusercontent.com/5812946/168286351-f0e8f4b7-e4c2-410b-a840-2fb9b8c25da0.png)

### Result

<img width="1853" alt="image" src="https://user-images.githubusercontent.com/5812946/168286502-ebcac065-2dc7-4937-bf8e-80fd14e34b0c.png">


## Environment

[https://b2borg--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations](https://b2borg--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations)
