### PR TITLE
[B2BORG-128] update message in bulk action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed organization bulk action button text.
+- Switched from `Remove from Org` to `Add to Org`
 
 ## [1.11.1] - 2022-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fixed organization bulk action button text.
-- Switched from `Remove from Org` to `Add to Org`
 
 ## [1.11.1] - 2022-07-04
 

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -153,7 +153,7 @@ const OrganizationDetailsCollections = ({
           }),
       },
       main: {
-        label: formatMessage(messages.removeFromOrg),
+        label: formatMessage(messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -153,7 +153,7 @@ const OrganizationDetailsCollections = ({
           }),
       },
       main: {
-        label: formatMessage(messages.addToOrg),
+        label: formatMessage(handleCallback.name === 'handleRemoveCollections' ? messages.removeFromOrg : messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -153,7 +153,11 @@ const OrganizationDetailsCollections = ({
           }),
       },
       main: {
-        label: formatMessage(handleCallback.name === 'handleRemoveCollections' ? messages.removeFromOrg : messages.addToOrg),
+        label: formatMessage(
+          handleCallback.name === 'handleRemoveCollections'
+            ? messages.removeFromOrg
+            : messages.addToOrg
+        ),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -79,8 +79,6 @@ const OrganizationDetailsPayTerms = ({
     )
 
     setPaymentTermsState(newPaymentTerms)
-
-    return messages.removeFromOrg
   }
 
   const handleAddPaymentTerms = (rowParams: {

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -112,7 +112,7 @@ const OrganizationDetailsPayTerms = ({
           }),
       },
       main: {
-        label: formatMessage(messages.removeFromOrg),
+        label: formatMessage(messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -79,6 +79,7 @@ const OrganizationDetailsPayTerms = ({
     )
 
     setPaymentTermsState(newPaymentTerms)
+    return messages.removeFromOrg
   }
 
   const handleAddPaymentTerms = (rowParams: {
@@ -112,7 +113,7 @@ const OrganizationDetailsPayTerms = ({
           }),
       },
       main: {
-        label: formatMessage(messages.addToOrg),
+        label: formatMessage(handleCallback.name === 'handleRemovePaymentTerms' ? messages.removeFromOrg : messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -79,6 +79,7 @@ const OrganizationDetailsPayTerms = ({
     )
 
     setPaymentTermsState(newPaymentTerms)
+
     return messages.removeFromOrg
   }
 
@@ -113,7 +114,11 @@ const OrganizationDetailsPayTerms = ({
           }),
       },
       main: {
-        label: formatMessage(handleCallback.name === 'handleRemovePaymentTerms' ? messages.removeFromOrg : messages.addToOrg),
+        label: formatMessage(
+          handleCallback.name === 'handleRemovePaymentTerms'
+            ? messages.removeFromOrg
+            : messages.addToOrg
+        ),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -110,7 +110,7 @@ const OrganizationDetailsPriceTables = ({
           }),
       },
       main: {
-        label: formatMessage(messages.addToOrg),
+        label: formatMessage(handleCallback.name === 'handleRemovePriceTables' ? messages.removeFromOrg : messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -110,7 +110,7 @@ const OrganizationDetailsPriceTables = ({
           }),
       },
       main: {
-        label: formatMessage(messages.removeFromOrg),
+        label: formatMessage(messages.addToOrg),
         handleCallback,
       },
     }

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -110,7 +110,11 @@ const OrganizationDetailsPriceTables = ({
           }),
       },
       main: {
-        label: formatMessage(handleCallback.name === 'handleRemovePriceTables' ? messages.removeFromOrg : messages.addToOrg),
+        label: formatMessage(
+          handleCallback.name === 'handleRemovePriceTables'
+            ? messages.removeFromOrg
+            : messages.addToOrg
+        ),
         handleCallback,
       },
     }


### PR DESCRIPTION
#### What problem is this solving?
- The message on the bulk actions in the b2b org settings might be misleading. This needs to be adjusted. 

#### Changes made:
- Update the text from bulk actions text
- Change message from `messages.removeFromOrg` to `messages.addToOrg`
- This change was applied to the following tabs: `Price Tables, Payment Terms, Collections`

#### How to test it?
- This can be test on [this](https://beto--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/1edc154f-b557-11ec-835d-126883cbf753/#/price-tables) environment

#### Screenshots or example usage:
![Image 2022-06-28 at 12 15 54 p m](https://user-images.githubusercontent.com/11176519/176243355-f6785f27-6495-43fc-8b1a-c1b375720133.jpg)
