### PR TITLE
Refresh page if authenticated and autocreate enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added Auto Refresh when the user is authenticated and `Auto Approve` is enabled
+
 ## [1.22.1] - 2023-03-01
 
 ### Fixed

--- a/react/components/RequestOrganizationForm.tsx
+++ b/react/components/RequestOrganizationForm.tsx
@@ -285,7 +285,15 @@ const RequestOrganizationForm: FC = () => {
           requestId = response.data.createOrganizationRequest.id
           localStore.setItem('b2b-organizations_orgRequestId', requestId)
           toastMessage(messages.toastSuccess)
-          refetch({ id: requestId })
+          refetch({ id: requestId }).then(res => {
+            if (
+              res.data?.getOrganizationRequestById.status !== 'pending' &&
+              sessionResponse.namespaces?.profile?.isAuthenticated?.value ===
+                'true'
+            ) {
+              window.location.pathname = '/'
+            }
+          })
           window.scrollTo({ top: 0, behavior: 'smooth' })
           setFormState({
             ...formState,


### PR DESCRIPTION
#### What problem is this solving?

- Currently when the user creates an organization, they are stuck on the same page.
- When the user is authenticated, the page needs to auto refresh so they can see the products

#### How to test it?
You can test it [here](https://albertob2b--b2bstoreqa.myvtex.com/)
Scenarios: 
- Create an Organization without signing in, go straight to `/organization-request` 
**Expected Result**
_Should not redirect you because you are not authenticated_ 
- Create an Organization and have the `Auto Approve` enabled
**Expected Result**
_Should not redirect you because you are not authenticated_ 
- Sign in and create an Organization
**Expected Result**
_Should redirect you because you are authenticated_ 