### PR TITLE
[FSEUS-72] Add CSS handle to hide button on account storefront

### DIFF
--- a/react/components/OrganizationDetails.tsx
+++ b/react/components/OrganizationDetails.tsx
@@ -11,6 +11,7 @@ import {
 } from 'vtex.styleguide'
 import { useQuery, useMutation } from 'react-apollo'
 
+import { useCssHandles } from 'vtex.css-handles'
 import { organizationMessages as messages } from './utils/messages'
 import storageFactory from '../utils/storage'
 import { useSessionResponse } from '../modules/session'
@@ -52,6 +53,8 @@ interface Role {
   slug: string
 }
 
+const CSS_HANDLES = ['createCostCenter'] as const
+
 const localStore = storageFactory(() => localStorage)
 let isAuthenticated =
   JSON.parse(String(localStore.getItem('b2b-organizations_isAuthenticated'))) ??
@@ -62,6 +65,7 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
   history,
 }) => {
   const sessionResponse: any = useSessionResponse()
+  const handles = useCssHandles(CSS_HANDLES)
 
   if (sessionResponse) {
     isAuthenticated =
@@ -303,54 +307,56 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
       }
     >
       {roleState && !isSales() && (
-        <PageBlock title={formatMessage(messages.costCenters)}>
-          <Table
-            fullWidth
-            schema={getCostCenterSchema()}
-            items={
-              costCentersData?.getCostCentersByOrganizationIdStorefront?.data
-            }
-            loading={costCentersLoading}
-            onRowClick={({ rowData: { id } }: CellRendererProps) => {
-              if (!id) return
+        <div className={`${handles.createCostCenter}`}>
+          <PageBlock title={formatMessage(messages.costCenters)}>
+            <Table
+              fullWidth
+              schema={getCostCenterSchema()}
+              items={
+                costCentersData?.getCostCentersByOrganizationIdStorefront?.data
+              }
+              loading={costCentersLoading}
+              onRowClick={({ rowData: { id } }: CellRendererProps) => {
+                if (!id) return
 
-              history.push(`/cost-center/${id}`)
-            }}
-            pagination={{
-              onNextClick: handleCostCentersNextClick,
-              onPrevClick: handleCostCentersPrevClick,
-              onRowsChange: handleCostCentersRowsChange,
-              currentItemFrom:
-                (costCenterPaginationState.page - 1) *
-                  costCenterPaginationState.pageSize +
-                1,
-              currentItemTo:
-                costCentersData?.getCostCentersByOrganizationIdStorefront
-                  ?.pagination?.total <
-                costCenterPaginationState.page *
-                  costCenterPaginationState.pageSize
-                  ? costCentersData?.getCostCentersByOrganizationIdStorefront
-                      ?.pagination?.total
-                  : costCenterPaginationState.page *
-                    costCenterPaginationState.pageSize,
-              textShowRows: formatMessage(messages.showRows),
-              textOf: formatMessage(messages.of),
-              totalItems:
-                costCentersData?.getCostCentersByOrganizationIdStorefront
-                  ?.pagination?.total ?? 0,
-              rowsOptions: [25, 50, 100],
-            }}
-            toolbar={{
-              newLine: {
-                label: formatMessage(messages.new),
-                handleCallback: () => setNewCostCenterModalState(true),
-                disabled: !permissionsState.includes(
-                  'create-cost-center-organization'
-                ),
-              },
-            }}
-          />
-        </PageBlock>
+                history.push(`/cost-center/${id}`)
+              }}
+              pagination={{
+                onNextClick: handleCostCentersNextClick,
+                onPrevClick: handleCostCentersPrevClick,
+                onRowsChange: handleCostCentersRowsChange,
+                currentItemFrom:
+                  (costCenterPaginationState.page - 1) *
+                    costCenterPaginationState.pageSize +
+                  1,
+                currentItemTo:
+                  costCentersData?.getCostCentersByOrganizationIdStorefront
+                    ?.pagination?.total <
+                  costCenterPaginationState.page *
+                    costCenterPaginationState.pageSize
+                    ? costCentersData?.getCostCentersByOrganizationIdStorefront
+                        ?.pagination?.total
+                    : costCenterPaginationState.page *
+                      costCenterPaginationState.pageSize,
+                textShowRows: formatMessage(messages.showRows),
+                textOf: formatMessage(messages.of),
+                totalItems:
+                  costCentersData?.getCostCentersByOrganizationIdStorefront
+                    ?.pagination?.total ?? 0,
+                rowsOptions: [25, 50, 100],
+              }}
+              toolbar={{
+                newLine: {
+                  label: formatMessage(messages.new),
+                  handleCallback: () => setNewCostCenterModalState(true),
+                  disabled: !permissionsState.includes(
+                    'create-cost-center-organization'
+                  ),
+                },
+              }}
+            />
+          </PageBlock>
+        </div>
       )}
 
       {roleState && isSalesAdmin() && <OrganizationsWithoutSalesManager />}


### PR DESCRIPTION
#### What problem is this solving?
- Client wants to hide vtex button, but they need a CSS selector in order to hide this button
- A css handle class was added to the parent container in order to select the `vtex-button` as a child and add a `display: none` style to it. 

#### How to test it?
- You can test [here](https://alberto--whitebird.myvtex.com/)
- You can go to your account, under the my organizations, you should be able to see that the parent container for the `cost center creation` has a class added to it. 

#### Screenshots or example usage:
![Image 2023-03-21 at 3 59 28 p m](https://user-images.githubusercontent.com/11176519/226751146-f1c982ae-625a-4e02-8a0c-8527e5252dd7.jpg)

#### How does this PR make you feel? [:link:](https://media.giphy.com/media/JJGUejl0pLcRy/giphy.gif)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/JJGUejl0pLcRy/giphy.gif)
