### PR TITLE
Add cost center details CSS Handles to hide specific fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added CssHandle class to cost center details
+
 ## [1.22.6] - 2023-03-28
 
 ### Fixed

--- a/react/admin/CostCenterDetails.tsx
+++ b/react/admin/CostCenterDetails.tsx
@@ -19,6 +19,7 @@ import {
 import { useToast } from '@vtex/admin-ui'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
 import {
   AddressRules,
   AddressSummary,
@@ -47,6 +48,8 @@ import GET_B2B_CUSTOM_FIELDS from '../graphql/getB2BCustomFields.graphql'
 import { joinById } from './OrganizationDetails'
 import CustomFieldInput from './OrganizationDetailsCustomField'
 
+const CSS_HANDLES = ['businessDocument', 'stateRegistration'] as const
+
 const CostCenterDetails: FunctionComponent = () => {
   const { formatMessage } = useIntl()
 
@@ -56,6 +59,7 @@ const CostCenterDetails: FunctionComponent = () => {
     navigate,
   } = useRuntime()
 
+  const handles = useCssHandles(CSS_HANDLES)
   const showToast = useToast()
 
   const [loadingState, setLoadingState] = useState(false)
@@ -532,7 +536,7 @@ const CostCenterDetails: FunctionComponent = () => {
             }}
           />
         </div>
-        <div className="mt6">
+        <div className={`${handles.businessDocument} mt6`}>
           <Input
             autocomplete="off"
             size="large"
@@ -544,7 +548,7 @@ const CostCenterDetails: FunctionComponent = () => {
             }}
           />
         </div>
-        <div className="mt6">
+        <div className={`${handles.stateRegistration} mt6`}>
           <Input
             autocomplete="off"
             size="large"

--- a/react/components/CostCenterDetails.tsx
+++ b/react/components/CostCenterDetails.tsx
@@ -16,6 +16,7 @@ import {
 } from 'vtex.styleguide'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { AddressRules, AddressSummary } from 'vtex.address-form'
+import { useCssHandles } from 'vtex.css-handles'
 
 import { costCenterMessages as messages } from './utils/messages'
 import storageFactory from '../utils/storage'
@@ -49,6 +50,8 @@ interface PaymentTerm {
   name: string
 }
 
+const CSS_HANDLES = ['businessDocument', 'stateRegistration'] as const
+
 const localStore = storageFactory(() => localStorage)
 let isAuthenticated =
   JSON.parse(String(localStore.getItem('b2b-organizations_isAuthenticated'))) ??
@@ -72,6 +75,7 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
     )
   }
 
+  const handles = useCssHandles(CSS_HANDLES)
   const { showToast } = useContext(ToastContext)
 
   const toastMessage = (message: MessageDescriptor) => {
@@ -531,7 +535,7 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
             }
           />
         </div>
-        <div className="mt6">
+        <div className={`${handles.businessDocument} mt6`}>
           <Input
             autocomplete="off"
             size="large"
@@ -546,7 +550,7 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
             }
           />
         </div>
-        <div className="mt6">
+        <div className={`${handles.stateRegistration} mt6`}>
           <Input
             autocomplete="off"
             size="large"


### PR DESCRIPTION
#### What problem is this solving?
- A client is currently trying to hide a couple of fields in the Cost Center details page
- Css Handles were added in order to achieve request

#### How to test it?
- You can test it [here](https://alberto--whitebird.myvtex.com/)

#### Screenshots or example usage:
![Image 2023-03-28 at 6 15 31 a m](https://user-images.githubusercontent.com/11176519/228233282-31776e43-ff2c-4131-bee3-a520ec3e5b52.jpg)
