### PR TITLE
Feature/make fields readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added added condition in order to show business and state field disabled
+
 ## [1.22.7] - 2023-03-28
 
 ### Added

--- a/messages/context.json
+++ b/messages/context.json
@@ -327,6 +327,8 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-failure": "admin/b2b-organizations.organization-settings-admin.toast.update-failure",
   "admin/b2b-organizations.organization-settings-admin.saveSettings": "admin/b2b-organizations.organization-settings-admin.saveSettings",
   "admin/b2b-organizations.organization-settings-admin.autoApprove": "admin/b2b-organizations.organization-settings-admin.autoApprove",
+  "admin/b2b-organizations.organization-settings-admin.businessReadOnly": "admin/b2b-organizations.organization-settings-admin.businessReadOnly",
+  "admin/b2b-organizations.organization-settings-admin.stateReadOnly": "admin/b2b-organizations.organization-settings-admin.stateReadOnly",
   "admin/b2b-organizations.organization-settings-admin.selectedPaymentsTableTitle": "admin/b2b-organizations.organization-settings-admin.selectedPaymentsTableTitle",
   "admin/b2b-organizations.organization-settings-admin.availablePaymentsTableTitle": "admin/b2b-organizations.organization-settings-admin.availablePaymentsTableTitle",
   "admin/b2b-organizations.organization-settings-admin.selectedPriceTablesTitle": "admin/b2b-organizations.organization-settings-admin.selectedPriceTablesTitle",

--- a/messages/en.json
+++ b/messages/en.json
@@ -328,6 +328,8 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-failure": "Update failed, see console for details",
   "admin/b2b-organizations.organization-settings-admin.saveSettings": "Save Settings",
   "admin/b2b-organizations.organization-settings-admin.autoApprove": "Auto approve new organizations",
+  "admin/b2b-organizations.organization-settings-admin.businessReadOnly": "Make business document ready only",
+  "admin/b2b-organizations.organization-settings-admin.stateReadOnly": "Make state registration ready only",
   "admin/b2b-organizations.organization-settings-admin.selectedPaymentsTableTitle": "Selected Payment Terms",
   "admin/b2b-organizations.organization-settings-admin.availablePaymentsTableTitle": "Available Payment Terms",
   "admin/b2b-organizations.organization-settings-admin.selectedPriceTablesTitle": "Selected Price tables",

--- a/react/admin/OrganizationSettings.tsx
+++ b/react/admin/OrganizationSettings.tsx
@@ -46,6 +46,7 @@ const OrganizationSettings: FunctionComponent = () => {
   const [loading, setLoading] = useState(false)
   const [settings, setSettings] = useState({
     autoApprove: false,
+    companyReadOnly: false,
     defaultPaymentTerms: [] as any,
     defaultPriceTables: [] as any,
     uiSettings: {
@@ -119,6 +120,7 @@ const OrganizationSettings: FunctionComponent = () => {
 
     setSettings({
       autoApprove: getB2BSettings?.autoApprove,
+      companyReadOnly: getB2BSettings?.companyReadOnly,
       defaultPaymentTerms: getB2BSettings?.defaultPaymentTerms ?? [],
       defaultPriceTables: getB2BSettings?.defaultPriceTables ?? [],
       uiSettings: {
@@ -291,6 +293,23 @@ const OrganizationSettings: FunctionComponent = () => {
           <div className="mb4">
             <Checkbox
               checked={settings.uiSettings.showModal}
+              id="showModal"
+              name="showModal"
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  uiSettings: {
+                    ...settings.uiSettings,
+                    showModal: !settings.uiSettings.showModal,
+                  },
+                })
+              }}
+              label={formatMessage(messages.showModal)}
+            />
+          </div>
+          <div className="mb4">
+            <Checkbox
+              checked={settings.companyReadOnly}
               id="showModal"
               name="showModal"
               onChange={() => {

--- a/react/admin/OrganizationSettings.tsx
+++ b/react/admin/OrganizationSettings.tsx
@@ -46,7 +46,8 @@ const OrganizationSettings: FunctionComponent = () => {
   const [loading, setLoading] = useState(false)
   const [settings, setSettings] = useState({
     autoApprove: false,
-    companyReadOnly: false,
+    businessReadOnly: false,
+    stateReadOnly: false,
     defaultPaymentTerms: [] as any,
     defaultPriceTables: [] as any,
     uiSettings: {
@@ -120,7 +121,8 @@ const OrganizationSettings: FunctionComponent = () => {
 
     setSettings({
       autoApprove: getB2BSettings?.autoApprove,
-      companyReadOnly: getB2BSettings?.companyReadOnly,
+      businessReadOnly: getB2BSettings?.businessReadOnly,
+      stateReadOnly: getB2BSettings?.stateReadOnly,
       defaultPaymentTerms: getB2BSettings?.defaultPaymentTerms ?? [],
       defaultPriceTables: getB2BSettings?.defaultPriceTables ?? [],
       uiSettings: {
@@ -292,24 +294,35 @@ const OrganizationSettings: FunctionComponent = () => {
           </div>
           <div className="mb4">
             <Checkbox
-              checked={settings.uiSettings.showModal}
-              id="showModal"
-              name="showModal"
+              checked={settings.businessReadOnly}
+              id="businessReadOnly"
+              name="businessReadOnly"
               onChange={() => {
                 setSettings({
                   ...settings,
-                  uiSettings: {
-                    ...settings.uiSettings,
-                    showModal: !settings.uiSettings.showModal,
-                  },
+                  businessReadOnly: !settings.businessReadOnly,
                 })
               }}
-              label={formatMessage(messages.showModal)}
+              label={formatMessage(messages.businessReadOnly)}
             />
           </div>
           <div className="mb4">
             <Checkbox
-              checked={settings.companyReadOnly}
+              checked={settings.stateReadOnly}
+              id="stateReadOnly"
+              name="stateReadOnly"
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  stateReadOnly: !settings.stateReadOnly,
+                })
+              }}
+              label={formatMessage(messages.stateReadOnly)}
+            />
+          </div>
+          <div className="mb4">
+            <Checkbox
+              checked={settings.uiSettings.showModal}
               id="showModal"
               name="showModal"
               onChange={() => {

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -408,6 +408,12 @@ export const organizationSettingsMessages = defineMessages({
   autoApprove: {
     id: `${adminPrefix}organization-settings-admin.autoApprove`,
   },
+  businessReadOnly: {
+    id: `${adminPrefix}organization-settings-admin.businessReadOnly`,
+  },
+  stateReadOnly: {
+    id: `${adminPrefix}organization-settings-admin.stateReadOnly`,
+  },
   saveSettings: {
     id: `${adminPrefix}organization-settings-admin.saveSettings`,
   },

--- a/react/components/CostCenterDetails.tsx
+++ b/react/components/CostCenterDetails.tsx
@@ -32,6 +32,7 @@ import GET_ORGANIZATION from '../graphql/getOrganizationStorefront.graphql'
 import UPDATE_COST_CENTER from '../graphql/updateCostCenter.graphql'
 import DELETE_COST_CENTER from '../graphql/deleteCostCenter.graphql'
 import GET_PERMISSIONS from '../graphql/getPermissions.graphql'
+import GET_B2B_SETTINGS from '../graphql/getB2BSettings.graphql'
 
 interface RouterProps {
   match: Match
@@ -98,6 +99,11 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
     [] as PaymentTerm[]
   )
 
+  const [settings, setSettings] = useState({
+    businessReadOnly: false,
+    stateReadOnly: false,
+  })
+
   const [newAddressModalState, setNewAddressModalState] = useState({
     isOpen: false,
   })
@@ -126,6 +132,8 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
   const [getOrganization, { data: organizationData }] = useLazyQuery(
     GET_ORGANIZATION
   )
+
+  const { data: dataSettings } = useQuery(GET_B2B_SETTINGS, { ssr: false })
 
   const { data: permissionsData } = useQuery(GET_PERMISSIONS, { ssr: false })
 
@@ -199,6 +207,19 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
       setPermissionsState(permissions)
     }
   }, [permissionsData])
+
+  useEffect(() => {
+    if (!dataSettings) {
+      return
+    }
+
+    const { getB2BSettings } = dataSettings
+
+    setSettings({
+      businessReadOnly: getB2BSettings?.businessReadOnly,
+      stateReadOnly: getB2BSettings?.stateReadOnly,
+    })
+  }, [dataSettings])
 
   const handleUpdateCostCenter = () => {
     setLoadingState(true)
@@ -546,7 +567,8 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
               setBusinessDocument(e.target.value)
             }}
             readOnly={
-              !permissionsState.includes('create-cost-center-organization')
+              !permissionsState.includes('create-cost-center-organization') ||
+              settings.businessReadOnly
             }
           />
         </div>
@@ -561,7 +583,8 @@ const CostCenterDetails: FunctionComponent<RouterProps> = ({
               setStateRegistration(e.target.value)
             }}
             readOnly={
-              !permissionsState.includes('create-cost-center-organization')
+              !permissionsState.includes('create-cost-center-organization') ||
+              settings.stateReadOnly
             }
           />
         </div>

--- a/react/graphql/getB2BSettings.graphql
+++ b/react/graphql/getB2BSettings.graphql
@@ -1,6 +1,7 @@
 query GetB2BSettings {
   getB2BSettings @context(provider: "vtex.b2b-organizations-graphql") {
     autoApprove
+    companyReadOny
     defaultPaymentTerms {
       id
       name

--- a/react/graphql/getB2BSettings.graphql
+++ b/react/graphql/getB2BSettings.graphql
@@ -1,7 +1,8 @@
 query GetB2BSettings {
   getB2BSettings @context(provider: "vtex.b2b-organizations-graphql") {
     autoApprove
-    companyReadOny
+    businessReadOnly
+    stateReadOnly
     defaultPaymentTerms {
       id
       name


### PR DESCRIPTION
#### What problem is this solving?
- In the B2B setting we added a setting in order to allow admins to make a couple of fields read only

#### How to test it?
- You can test [here](https://albertob2borg--sandboxusdev.myvtex.com/)

#### Screenshots or example usage:
![Image 2023-03-31 at 5 02 43 p m](https://user-images.githubusercontent.com/11176519/229247605-f8235ba4-5bba-4470-a1c0-9f117b1bf07c.jpg)
![Image 2023-03-31 at 5 15 36 p m](https://user-images.githubusercontent.com/11176519/229248681-38e8da94-0f08-45b8-b633-60ba5b908684.jpg)


#### Related to / Depends on
- https://github.com/vtex-apps/b2b-organizations-graphql/pull/104

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
