### PR TITLE
fix: Fixed pagination with organization ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pagination with organization ID
+
 ## [1.24.0] - 2023-04-11
 
 ### Fixed

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -461,6 +461,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     refetch({
       ...variableState,
       page: newPage,
+      organizationId: isSalesAdmin ? null : organizationId,
     })
   }
 
@@ -477,6 +478,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     refetch({
       ...variableState,
       page: newPage,
+      organizationId: isSalesAdmin ? null : organizationId,
     })
   }
 
@@ -495,6 +497,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
       ...variableState,
       page: 1,
       pageSize: +value,
+      organizationId: isSalesAdmin ? null : organizationId,
     })
   }
 
@@ -519,6 +522,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
       ...variableState,
       search: '',
       page: 1,
+      organizationId: isSalesAdmin ? null : organizationId,
     })
   }
 
@@ -572,6 +576,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     refetch({
       ...variableState,
       page: 1,
+      organizationId: isSalesAdmin ? null : organizationId,
       sortOrder: _sortOrder,
       sortedBy: _sortedBy,
     })


### PR DESCRIPTION
#### What problem is this solving?

Pagination on the users' table listing:

https://b2borg2--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/2b9ed078-c345-11ed-83ab-12ffcbcaa8a7/#/users
