### PR TITLE
feat: possibility of loading indicator on widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `showLoadingIndicator` prop on user widget which controls whether a loading indicator will be displayed while widget data is loading
+
 ## [1.24.2] - 2023-04-21
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,7 @@ CSS handles are available for the **Organization Request Form** component and th
 | `newOrganizationButtonsContainer` |
 | `newOrganizationButtonSubmit`     |
 | `userWidgetContainer`             |
+| `userWidgetLoading`             |
 | `userWidgetRow`                   |
 | `userWidgetItem`                  |
 | `userWidgetButton`                |

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ if we have more than one associated organization:
 | Prop name                  | Type                              | Description                                                                                                             | Default value |
 | -------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `showDropdown`               | `Boolean`                          | controls whether we are viewing the dropdown if we have more than one organization associated with the same email.                  | `true`          |
+| `showLoadingIndicator`       | `Boolean`                          | controls whether a loading indicator will be displayed while widget data is loading.                                                | `false`          |
 ## Customization
 
 In order to apply CSS customizations in this and other apps, follow the instructions on [Using CSS Handles for store customization](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-using-css-handles-for-store-customization).

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -2,7 +2,14 @@ import React, { Fragment, useEffect, useState } from 'react'
 import type { FunctionComponent } from 'react'
 import { useQuery, useMutation } from 'react-apollo'
 import { useIntl, FormattedMessage } from 'react-intl'
-import { AutocompleteInput, Button, Input, Modal, Spinner, Tag } from 'vtex.styleguide'
+import {
+  AutocompleteInput,
+  Button,
+  Input,
+  Modal,
+  Spinner,
+  Tag,
+} from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { useRuntime } from 'vtex.render-runtime'
 
@@ -188,10 +195,13 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
     }
   }
 
-  const { data: userWidgetData, loading: userWidgetLoading } = useQuery(USER_WIDGET_QUERY, {
-    ssr: false,
-    skip: !isAuthenticated,
-  }) as any
+  const { data: userWidgetData, loading: userWidgetLoading } = useQuery(
+    USER_WIDGET_QUERY,
+    {
+      ssr: false,
+      skip: !isAuthenticated,
+    }
+  ) as any
 
   const [stopImpersonation] = useMutation(STOP_IMPERSONATION)
   const [setCurrentOrganization] = useMutation(SET_CURRENT_ORGANIZATION)

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -422,7 +422,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
 
   if (showLoadingIndicator && userWidgetLoading) {
     return (
-      <div className={`${handles.userWidgetLoading}`}>
+      <div className={handles.userWidgetLoading}>
         <Spinner color="currentColor" />
       </div>
     )

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useEffect, useState } from 'react'
 import type { FunctionComponent } from 'react'
 import { useQuery, useMutation } from 'react-apollo'
 import { useIntl, FormattedMessage } from 'react-intl'
-import { AutocompleteInput, Button, Input, Modal, Tag } from 'vtex.styleguide'
+import { AutocompleteInput, Button, Input, Modal, Spinner, Tag } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { useRuntime } from 'vtex.render-runtime'
 
@@ -116,6 +116,7 @@ interface VtexFunctionComponent<T = Record<string, unknown>>
 
 interface UserWidgetProps {
   showDropdown?: boolean
+  showLoadingIndicator?: boolean
 }
 
 const sortOrganizations = (a: any, b: any) =>
@@ -123,6 +124,7 @@ const sortOrganizations = (a: any, b: any) =>
 
 const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
   showDropdown = true,
+  showLoadingIndicator = false,
 }) => {
   const { navigate, rootPath } = useRuntime()
   const { formatMessage } = useIntl()
@@ -185,7 +187,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
     }
   }
 
-  const { data: userWidgetData } = useQuery(USER_WIDGET_QUERY, {
+  const { data: userWidgetData, loading: userWidgetLoading } = useQuery(USER_WIDGET_QUERY, {
     ssr: false,
     skip: !isAuthenticated,
   }) as any
@@ -415,6 +417,16 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
         currentCostCenter: itemSelected.value,
       })
     },
+  }
+
+  if (showLoadingIndicator && userWidgetLoading) {
+    return (
+      <div
+        className={`${handles.userWidgetRow} flex justify-center items-center pv8`}
+      >
+        <Spinner />
+      </div>
+    )
   }
 
   if (
@@ -693,6 +705,11 @@ UserWidget.schema = {
       title: 'showDropdown',
       type: 'boolean',
       default: true,
+    },
+    showLoadingIndicator: {
+      title: 'showLoadingIndicator',
+      type: 'boolean',
+      default: false,
     },
   },
 }

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -20,6 +20,7 @@ import '../css/user-widget.css'
 
 const CSS_HANDLES = [
   'userWidgetContainer',
+  'userWidgetLoading',
   'userWidgetRow',
   'userWidgetItem',
   'userWidgetButton',
@@ -421,10 +422,8 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
 
   if (showLoadingIndicator && userWidgetLoading) {
     return (
-      <div
-        className={`${handles.userWidgetRow} flex justify-center items-center pv8`}
-      >
-        <Spinner />
+      <div className={`${handles.userWidgetLoading}`}>
+        <Spinner color="currentColor" />
       </div>
     )
   }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -7,6 +7,11 @@
           "title": "showDropdown",
           "type": "boolean",
           "default": true
+        },
+        "showLoadingIndicator": {
+          "title": "showLoadingIndicator",
+          "type": "boolean",
+          "default": false
         }
       }
     }


### PR DESCRIPTION
#### What problem is this solving?

Prevent layout shifts between loading and loaded states of user widget data.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://dev--bravtexfashionb2b.myvtex.com/)

#### Screenshots or example usage:

Example usage on theme app:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
```json
"b2b-user-widget": {
  "props": {
    "showLoadingIndicator": true
  }
}
```

Preview gif: https://tiago-dev.com/files/screen-record.gif

In preview gif, the `b2b-user-widget` is inside a `overlay-layout` and widget loading indicator appears first on click at respective `overlay-trigger` (link with text "Minha Organização").