### PR TITLE
Fix missing back button in shopper my organizations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed missing back button in shopper my organizations page
+
 ## [1.24.3] - 2023-05-11
 
 ### Added

--- a/react/components/OrganizationDetails.tsx
+++ b/react/components/OrganizationDetails.tsx
@@ -299,11 +299,17 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
     <Layout
       fullWidth
       pageHeader={
-        roleState && !isSalesAdmin() ? (
-          <PageHeader title={data.getOrganizationByIdStorefront?.name} />
-        ) : (
-          <PageHeader title={formatMessage(messages.salesAdminTitle)} />
-        )
+        <PageHeader
+          title={
+            roleState && !isSalesAdmin()
+              ? data.getOrganizationByIdStorefront?.name
+              : formatMessage(messages.salesAdminTitle)
+          }
+          linkLabel={formatMessage(messages.back)}
+          onLinkClick={() => {
+            history.push(`/`)
+          }}
+        />
       }
     >
       {roleState && !isSales() && (

--- a/react/components/utils/messages.ts
+++ b/react/components/utils/messages.ts
@@ -135,6 +135,9 @@ export const organizationMessages = defineMessages({
   pageTitle: {
     id: `${storePrefix}organization-details.title`,
   },
+  back: {
+    id: `${storePrefix}back`,
+  },
   costCenters: {
     id: `${storePrefix}organization-details.costCenters`,
   },


### PR DESCRIPTION
#### What problem is this solving?

The "Back" button was not showing up in My Organization page under My Account, preventing the shopper from accessing other options from My Account when navigating on mobile.

#### How to test it?

* Login into the store
* Go to My Account menu
* Go to My Organization
* Click on back button at the top of the page and check it goes back to My Account page (or profile page if not on mobile)

[Workspace](https://enzo--osterclqab2b.myvtex.com/)

#### Screenshots or example usage:
![Captura de Tela 2023-05-11 às 12 38 16](https://github.com/vtex-apps/b2b-organizations/assets/131273915/48662192-1332-43b2-86eb-4c9d7ce21665)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on
N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/11j6oiwfuzwu9G/giphy-downsized.gif)
