### PR TITLE
fix: provide actual label instead of inferring from function .name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed button label when adding/removing collections/sellers/etc to/from org
+
 ## [1.24.4] - 2023-05-12
 
 ### Fixed

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -5,6 +5,7 @@ import { PageBlock, Table } from 'vtex.styleguide'
 import { useQuery } from 'react-apollo'
 
 import { organizationMessages as messages } from '../utils/messages'
+import { organizationBulkAction } from '../utils/organizationBulkAction'
 import GET_COLLECTIONS from '../../graphql/getCollections.graphql'
 
 export interface Collection {
@@ -144,25 +145,6 @@ const OrganizationDetailsCollections = ({
     setCollectionsState([...collectionsState, ...newCollections])
   }
 
-  const bulkActions = (handleCallback: (params: any) => void) => {
-    return {
-      texts: {
-        rowsSelected: (qty: number) =>
-          formatMessage(messages.selectedRows, {
-            qty,
-          }),
-      },
-      main: {
-        label: formatMessage(
-          handleCallback.name === 'handleRemoveCollections'
-            ? messages.removeFromOrg
-            : messages.addToOrg
-        ),
-        handleCallback,
-      },
-    }
-  }
-
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.collections)}>
@@ -174,7 +156,11 @@ const OrganizationDetailsCollections = ({
             fullWidth
             schema={getSchema()}
             items={collectionsState}
-            bulkActions={bulkActions(handleRemoveCollections)}
+            bulkActions={organizationBulkAction(
+              handleRemoveCollections,
+              messages.removeFromOrg,
+              formatMessage
+            )}
           />
         </div>
         <div>
@@ -205,7 +191,11 @@ const OrganizationDetailsCollections = ({
               totalItems: collectionsData?.collections?.paging?.total ?? 0,
               rowsOptions: [25, 50, 100],
             }}
-            bulkActions={bulkActions(handleAddCollections)}
+            bulkActions={organizationBulkAction(
+              handleAddCollections,
+              messages.addToOrg,
+              formatMessage
+            )}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPayTerms.tsx
@@ -4,6 +4,7 @@ import React, { Fragment, useEffect, useState } from 'react'
 import { useQuery } from 'react-apollo'
 
 import { organizationMessages as messages } from '../utils/messages'
+import { organizationBulkAction } from '../utils/organizationBulkAction'
 import GET_PAYMENT_TERMS from '../../graphql/getPaymentTerms.graphql'
 
 export interface PaymentTerm {
@@ -104,25 +105,6 @@ const OrganizationDetailsPayTerms = ({
     setPaymentTermsState([...paymentTermsState, ...newPaymentTerms])
   }
 
-  const bulkActions = (handleCallback: (params: any) => void) => {
-    return {
-      texts: {
-        rowsSelected: (qty: number) =>
-          formatMessage(messages.selectedRows, {
-            qty,
-          }),
-      },
-      main: {
-        label: formatMessage(
-          handleCallback.name === 'handleRemovePaymentTerms'
-            ? messages.removeFromOrg
-            : messages.addToOrg
-        ),
-        handleCallback,
-      },
-    }
-  }
-
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.paymentTerms)}>
@@ -134,7 +116,11 @@ const OrganizationDetailsPayTerms = ({
             fullWidth
             schema={getSchema()}
             items={paymentTermsState}
-            bulkActions={bulkActions(handleRemovePaymentTerms)}
+            bulkActions={organizationBulkAction(
+              handleRemovePaymentTerms,
+              messages.removeFromOrg,
+              formatMessage
+            )}
           />
         </div>
         <div>
@@ -145,7 +131,11 @@ const OrganizationDetailsPayTerms = ({
             fullWidth
             schema={getSchema('availablePayments')}
             items={paymentTermsOptions}
-            bulkActions={bulkActions(handleAddPaymentTerms)}
+            bulkActions={organizationBulkAction(
+              handleAddPaymentTerms,
+              messages.addToOrg,
+              formatMessage
+            )}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsPriceTables.tsx
@@ -4,6 +4,7 @@ import { PageBlock, Table } from 'vtex.styleguide'
 import { useQuery } from 'react-apollo'
 
 import { organizationMessages as messages } from '../utils/messages'
+import { organizationBulkAction } from '../utils/organizationBulkAction'
 import GET_PRICE_TABLES from '../../graphql/getPriceTables.graphql'
 
 export interface PriceTable {
@@ -85,25 +86,6 @@ const OrganizationDetailsPriceTables = ({
     setPriceTablesState((prevState: any) => [...prevState, ...newPriceTables])
   }
 
-  const bulkActions = (handleCallback: (params: any) => void) => {
-    return {
-      texts: {
-        rowsSelected: (qty: number) =>
-          formatMessage(messages.selectedRows, {
-            qty,
-          }),
-      },
-      main: {
-        label: formatMessage(
-          handleCallback.name === 'handleRemovePriceTables'
-            ? messages.removeFromOrg
-            : messages.addToOrg
-        ),
-        handleCallback,
-      },
-    }
-  }
-
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.priceTables)}>
@@ -123,7 +105,11 @@ const OrganizationDetailsPriceTables = ({
                   )?.name ?? priceTable,
               }
             })}
-            bulkActions={bulkActions(handleRemovePriceTables)}
+            bulkActions={organizationBulkAction(
+              handleRemovePriceTables,
+              messages.removeFromOrg,
+              formatMessage
+            )}
           />
         </div>
         <div>
@@ -134,7 +120,11 @@ const OrganizationDetailsPriceTables = ({
             fullWidth
             schema={getSchema('availablePriceTables')}
             items={priceTableOptions}
-            bulkActions={bulkActions(handleAddPriceTables)}
+            bulkActions={organizationBulkAction(
+              handleAddPriceTables,
+              messages.addToOrg,
+              formatMessage
+            )}
           />
         </div>
       </PageBlock>

--- a/react/admin/OrganizationDetails/OrganizationDetailsSellers.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsSellers.tsx
@@ -4,6 +4,7 @@ import { PageBlock, Table } from 'vtex.styleguide'
 import { useQuery } from 'react-apollo'
 
 import { organizationMessages as messages } from '../utils/messages'
+import { organizationBulkAction } from '../utils/organizationBulkAction'
 import GET_SELLERS from '../../graphql/getSellers.graphql'
 
 export interface Seller {
@@ -95,25 +96,6 @@ const OrganizationDetailsSellers = ({
     setSellersState((prevState: any) => [...prevState, ...newSellers])
   }
 
-  const bulkActions = (handleCallback: (params: any) => void) => {
-    return {
-      texts: {
-        rowsSelected: (qty: number) =>
-          formatMessage(messages.selectedRows, {
-            qty,
-          }),
-      },
-      main: {
-        label: formatMessage(
-          handleCallback.name === 'handleRemoveSellers'
-            ? messages.removeFromOrg
-            : messages.addToOrg
-        ),
-        handleCallback,
-      },
-    }
-  }
-
   return (
     <Fragment>
       <PageBlock variation="half" title={formatMessage(messages.sellers)}>
@@ -125,7 +107,11 @@ const OrganizationDetailsSellers = ({
             fullWidth
             schema={getSchema()}
             items={sellersState}
-            bulkActions={bulkActions(handleRemoveSellers)}
+            bulkActions={organizationBulkAction(
+              handleRemoveSellers,
+              messages.removeFromOrg,
+              formatMessage
+            )}
           />
         </div>
         <div>
@@ -135,7 +121,11 @@ const OrganizationDetailsSellers = ({
           <Table
             fullWidth
             schema={getSchema('availableSellers')}
-            bulkActions={bulkActions(handleAddSellers)}
+            bulkActions={organizationBulkAction(
+              handleAddSellers,
+              messages.addToOrg,
+              formatMessage
+            )}
             items={sellerOptions}
           />
         </div>

--- a/react/admin/OrganizationSettings.tsx
+++ b/react/admin/OrganizationSettings.tsx
@@ -9,6 +9,7 @@ import {
   organizationSettingsMessages as messages,
   organizationMessages,
 } from './utils/messages'
+import { organizationBulkAction } from './utils/organizationBulkAction'
 import GET_SALES_CHANNELS from '../graphql/getSalesChannels.graphql'
 import SELECTED_SALES_CHANNELS from '../graphql/getSelectedChannels.graphql'
 import UPDATE_SALES_CHANNELS from '../graphql/updateSalesChannels.graphql'
@@ -244,25 +245,6 @@ const OrganizationSettings: FunctionComponent = () => {
     setSelectedChannel(newBindingList)
   }
 
-  const bulkActions = (handleCallback: (params: any) => void) => {
-    return {
-      texts: {
-        rowsSelected: (qty: number) =>
-          formatMessage(messages.selectedRows, {
-            qty,
-          }),
-      },
-      main: {
-        label: formatMessage(
-          handleCallback.name === 'handleRemoveBinding'
-            ? messages.removeFromBinding
-            : messages.addToBinding
-        ),
-        handleCallback,
-      },
-    }
-  }
-
   return (
     <PageBlock
       title={formatMessage(messages.tablePageTitle)}
@@ -437,7 +419,11 @@ const OrganizationSettings: FunctionComponent = () => {
               fullWidth
               schema={defaultSchema}
               items={selectedChannels}
-              bulkActions={bulkActions(handleRemoveBinding)}
+              bulkActions={organizationBulkAction(
+                handleRemoveBinding,
+                messages.removeFromBinding,
+                formatMessage
+              )}
             />
           ) : null}
         </div>
@@ -449,7 +435,11 @@ const OrganizationSettings: FunctionComponent = () => {
             fullWidth
             schema={getSchema()}
             items={salesChannels}
-            bulkActions={bulkActions(handleAddBinding)}
+            bulkActions={organizationBulkAction(
+              handleAddBinding,
+              messages.addToBinding,
+              formatMessage
+            )}
           />
         </div>
       </div>

--- a/react/admin/utils/organizationBulkAction.ts
+++ b/react/admin/utils/organizationBulkAction.ts
@@ -1,0 +1,20 @@
+import { organizationMessages as messages } from './messages'
+
+export const organizationBulkAction = (
+  handleCallback: { (rowParams: any): void; (rowParams: any): void },
+  labelMessage: { id: string },
+  formatMessage: { (...args: any): unknown }
+) => {
+  return {
+    texts: {
+      rowsSelected: (qty: number) =>
+        formatMessage(messages.selectedRows, {
+          qty,
+        }),
+    },
+    main: {
+      label: formatMessage(labelMessage),
+      handleCallback,
+    },
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

The "Remove from org" button was not shown properly in a few places in the b2b organization admin page. That is because `.name` is not necessarily filled depending on how the build is done, which was the case here.
To avoid that, now we provide the proper label for the button instead of trying to infer from provided callback function name. 

#### How to test it?
Go into any organization details and try to add/remove something in the collections and/or payments options and/or sellers tab.
[Workspace](b2bsuite.myvtex.com/admin/b2b-organizations/organizations/)

#### Screenshots or example usage:
<img width="1345" alt="Captura de Tela 2023-05-26 às 08 45 42" src="https://github.com/vtex-apps/b2b-organizations/assets/131273915/d7da379c-05c1-41ea-9608-54f88e7eb944">

