### PR TITLE
Bump admin UI

### DIFF
--- a/react/admin/DefaultCustomField.tsx
+++ b/react/admin/DefaultCustomField.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Input, IconDelete, IconPlus, Toggle, Dropdown } from 'vtex.styleguide'
-import { Button, Flex } from '@vtex/admin-ui'
+import { Button, Flex, csx } from '@vtex/admin-ui'
 import { useIntl } from 'react-intl'
 
 import { organizationCustomFieldsMessages as customFieldsMessages } from './utils/messages'
@@ -216,9 +216,9 @@ const DefaultCustomField: React.FC<CustomFieldProps> = ({
                     )}
                     variant="secondary"
                     onClick={() => handleDeleteDropdownItem(i)}
-                    csx={{
+                    className={csx({
                       marginLeft: '10px',
-                    }}
+                    })}
                   />
                 </Flex>
               )
@@ -239,10 +239,10 @@ const DefaultCustomField: React.FC<CustomFieldProps> = ({
             customFieldsMessages.customFieldsAddDropdownLine
           )}
           onClick={handleAddDropdownItem}
-          csx={{
+          className={csx({
             marginTop: '35px',
             marginLeft: '10px',
-          }}
+          })}
         />
       ) : null}
     </div>

--- a/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
@@ -20,7 +20,7 @@ import {
   PostalCodeGetter,
 } from 'vtex.address-form'
 import { StyleguideInput } from 'vtex.address-form/inputs'
-import type { Toast } from '@vtex/admin-ui/dist/components/Toast/types'
+import type { ToastProps } from '@vtex/admin-ui'
 
 import GET_COST_CENTERS from '../../graphql/getCostCentersByOrganizationId.graphql'
 import type { CellRendererProps } from '../OrganizationDetails'
@@ -44,7 +44,7 @@ const OrganizationDetailsCostCenters = ({
   loadingState,
 }: {
   setLoadingState: (state: boolean) => void
-  showToast: (toast: Toast) => void
+  showToast: (toast: ToastProps) => void
   loadingState: boolean
 }) => {
   /**

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide"
   },
   "dependencies": {
-    "@vtex/admin-ui": "^0.135.0",
+    "@vtex/admin-ui": "^0.136.1",
     "@vtex/css-handles": "^1.0.0",
     "apollo-client": "^2.6.10",
     "react": "^16.9.2",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2136,46 +2136,35 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/admin-ui-core@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-core/-/admin-ui-core-0.13.0.tgz#92b5f902176fd6290e4d8c9bf3221904791def6b"
-  integrity sha512-tjZfK7205aN36TVtF7ICCHi/LTgY42dTMmJxZZhdLZjMheOWtB30GDeEuQ3Bu4dW7t3fOiWjg8t9XOX4R7NjhQ==
+"@vtex/admin-ui-core@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-core/-/admin-ui-core-0.13.2.tgz#64a7c3d82244ccedc531f449e859213d1054fd87"
+  integrity sha512-lq1uaz1GxOF+anEDN32PiEKsLpty4jY8L/FTsogIkO/jGatI3vXDI6CYK57e/mG/h8XzQ4v/7RgPluIm1roSYQ==
   dependencies:
     "@stitches/react" "1.2.8"
-    "@vtex/admin-ui-util" "^0.5.0"
+    "@vtex/admin-ui-util" "^0.5.2"
     csstype "3.0.10"
 
-"@vtex/admin-ui-hooks@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-hooks/-/admin-ui-hooks-0.5.0.tgz#16699703de3dd174af4ed0574e01044fbf24e6b7"
-  integrity sha512-kWHhwhD/4Lk69nX72VmT+PNdfGMhm4LMlF/b3gUhuSbKWsVmddZGXl4mjHFWV2iqJoE485PPdy6RmhmmJUHsyg==
+"@vtex/admin-ui-hooks@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-hooks/-/admin-ui-hooks-0.5.2.tgz#bd04d22e8d110ecd70675a07fc3b1d835f831d0b"
+  integrity sha512-26do5XJVGP1j44YYG476eiNFHpa2AmwQZbD0l1DG06u/vAsMnfkrifybdYL3dJRjF89FVkMINZT9afqh3QWmQg==
   dependencies:
-    "@vtex/admin-ui-util" "^0.5.0"
+    "@vtex/admin-ui-util" "^0.5.2"
     tiny-invariant "^1.2.0"
     use-debounce "^7.0.0"
 
-"@vtex/admin-ui-react@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-react/-/admin-ui-react-0.10.0.tgz#2ab3892ebf938e08a03bf2ee7a1ac27dbf552faf"
-  integrity sha512-OliuHkIABt0M5r5k38d9mMPKYqg3FLKo5b42fNc3pXhdSJ48xl7JRavIvERqlNFUsx1sKefoLyyYLLq2PebVTA==
-  dependencies:
-    focus-visible "^5.2.0"
-    react-helmet "^6.1.0"
-    react-is "^17.0.2"
-    tiny-invariant "^1.1.0"
-    tiny-warning "^1.0.3"
-
-"@vtex/admin-ui-util@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-util/-/admin-ui-util-0.5.0.tgz#24087a0735678b08c1d4d547dad7f19ac6a9b9be"
-  integrity sha512-N98cXpdLbEdDXpfsWq+Xuq0q9jjGH7FGTuhUhY5dkO+BJgTp7QJMtEDu9WxuOXbAU11+enE9vBTi9ByNEB7o3w==
+"@vtex/admin-ui-util@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-util/-/admin-ui-util-0.5.2.tgz#74ff4547ef0371cfb2530edc5802c91813796358"
+  integrity sha512-1N10W9XhxRbptDFB4oKuDwkm//ubTttll93YOeXWIs0HguqIFs5bsXJmjSHQU93LnSGoyCzC0/7SjDCp5E/53Q==
   dependencies:
     deepmerge "4.2.2"
 
-"@vtex/admin-ui@^0.135.0":
-  version "0.135.0"
-  resolved "https://registry.yarnpkg.com/@vtex/admin-ui/-/admin-ui-0.135.0.tgz#33eb7bdfb42f9b7c013651bcda04e3fa040438b2"
-  integrity sha512-eWlXN+GW1Miv9jzs+Urjz2eSdO55DRpkpYJ/8fwZqZdFQk2YG2EldSLt7rZHlGNi4ysyvMFwBpR8mWWzttnjuQ==
+"@vtex/admin-ui@^0.136.1":
+  version "0.136.1"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui/-/admin-ui-0.136.1.tgz#8ead005f952898a28f93c48450c6c266d9794cbe"
+  integrity sha512-ZmCOsnDqKKu1u582k/D3zFAyKMeznVVp0cHKfKWNpWx3XwCuno6akruT0ZAKYM5Fgj1qH20Z7fCqEJBB/4rSWg==
   dependencies:
     "@babel/core" "^7.17.10"
     "@react-aria/i18n" "^3.3.5"
@@ -2184,18 +2173,19 @@
     "@react-aria/utils" "^3.3.5"
     "@react-stately/collections" "^3.3.5"
     "@react-stately/list" "^3.4.1"
-    "@vtex/admin-ui-core" "^0.13.0"
-    "@vtex/admin-ui-hooks" "^0.5.0"
-    "@vtex/admin-ui-react" "^0.10.0"
-    "@vtex/admin-ui-util" "^0.5.0"
+    "@vtex/admin-ui-core" "^0.13.2"
+    "@vtex/admin-ui-hooks" "^0.5.2"
+    "@vtex/admin-ui-util" "^0.5.2"
     "@vtex/phosphor-icons" "0.2.8"
     ariakit "2.0.0-next.39"
     csstype "3.0.10"
     date-fns "^2.28.0"
     downshift "^6.0.6"
+    focus-visible "^5.2.0"
     jotai "^1.9.2"
     react-collapsed "^3.3.0"
     react-device-detect "^1.15.0"
+    react-helmet "6.1.0"
     react-is "^17.0.1"
     reakit "^1.3.11"
     tiny-invariant "^1.1.0"
@@ -5043,7 +5033,7 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet@^6.1.0:
+react-helmet@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
   integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==


### PR DESCRIPTION
#### What problem is this solving?

Updates the @vtex/admin-ui to the most recent version. 

#### How to test it?

Use [this workspace](https://mairab2badminui--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations) and navigate around the organization admin pages. The most affected one is the [Custom Fields page](https://mairab2badminui--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations/#/custom-fields) which uses the library more than the others and required a fix for a breaking change from the upgrade. I've used the buttons/dropdowns and it's all working like before.
