### PR TITLE
Update layout and tabs to the new admin style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update layout and tabs to the new admin style
+
 ## [1.24.6] - 2023-07-11
 
 ### Changed

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -1,5 +1,15 @@
 import React from 'react'
-import { PageHeader, PageBlock, Layout, Tabs, Tab } from 'vtex.styleguide'
+import {
+  Page,
+  PageHeader,
+  PageHeaderTop,
+  PageHeaderTitle,
+  PageHeaderBottom,
+  TabList,
+  Tab,
+  PageContent,
+  useTabState,
+} from '@vtex/admin-ui'
 import { useIntl } from 'react-intl'
 import { HashRouter, Switch, Route } from 'react-router-dom'
 
@@ -17,12 +27,6 @@ import CheckCustomerSchema from '../components/CheckCustomerSchema'
 
 const SESSION_STORAGE_KEY = 'organization-tab'
 
-const Container = ({ children }: any) => (
-  <div className="mt6">
-    <PageBlock>{children}</PageBlock>
-  </div>
-)
-
 const OrganizationsTable = () => {
   const { formatMessage } = useIntl()
   const { tab, handleTabChange, routerRef } = useHashRouter({
@@ -31,35 +35,44 @@ const OrganizationsTable = () => {
     routes: ['organizations', 'requests', 'settings', 'custom-fields'],
   })
 
+  const tabsState = useTabState({ selectedId: tab })
+
   return (
-    <Layout
-      fullWidth
-      pageHeader={<PageHeader title={formatMessage(messages.tablePageTitle)} />}
-    >
-      <HashRouter ref={routerRef}>
-        <Tabs>
-          <Tab
-            label={formatMessage(messages.tablePageTitle)}
-            active={tab === 'organizations'}
-            onClick={() => handleTabChange('organizations')}
-          />
-          <Tab
-            label={formatMessage(requestMessages.tablePageTitle)}
-            active={tab === 'requests'}
-            onClick={() => handleTabChange('requests')}
-          />
-          <Tab
-            label={formatMessage(settingsMessages.tablePageTitle)}
-            active={tab === 'settings'}
-            onClick={() => handleTabChange('settings')}
-          />
-          <Tab
-            label={formatMessage(settingsMessages.customFieldsTitle)}
-            active={tab === 'custom-fields'}
-            onClick={() => handleTabChange('custom-fields')}
-          />
-        </Tabs>
-        <Container>
+    <HashRouter ref={routerRef}>
+      <Page>
+        <PageHeader>
+          <PageHeaderTop>
+            <PageHeaderTitle>
+              {formatMessage(messages.tablePageTitle)}
+            </PageHeaderTitle>
+          </PageHeaderTop>
+          <PageHeaderBottom>
+            <TabList state={tabsState}>
+              <Tab
+                id="organizations"
+                onClick={() => handleTabChange('organizations')}
+              >
+                {formatMessage(messages.tablePageTitle)}
+              </Tab>
+
+              <Tab id="requests" onClick={() => handleTabChange('requests')}>
+                {formatMessage(requestMessages.tablePageTitle)}
+              </Tab>
+
+              <Tab id="settings" onClick={() => handleTabChange('settings')}>
+                {formatMessage(settingsMessages.tablePageTitle)}
+              </Tab>
+
+              <Tab
+                id="custom-fields"
+                onClick={() => handleTabChange('custom-fields')}
+              >
+                {formatMessage(settingsMessages.customFieldsTitle)}
+              </Tab>
+            </TabList>
+          </PageHeaderBottom>
+        </PageHeader>
+        <PageContent layout="wide">
           <div className="mb5">
             <CheckCustomerSchema isAdmin={true} />
           </div>
@@ -77,9 +90,9 @@ const OrganizationsTable = () => {
               component={OrganizationCustomFields}
             />
           </Switch>
-        </Container>
-      </HashRouter>
-    </Layout>
+        </PageContent>
+      </Page>
+    </HashRouter>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Updating the layout and tabs of the organizations pages to use Admin UI instead of Styleguide. This will make it more consistent with the rest of the admin as well as with features that we're planning to add to these pages. 

#### How to test it?

The following workspace has the new style. I've verified that all 4 pages are working as expected, and that switching between them works, as well as refreshing the page after switching tabs.

[Workspace](https://mairatabs--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations/#/organizations)

#### Screenshots or example usage:

**Before**
<img width="1435" alt="Screenshot 2023-07-13 at 13 23 59" src="https://github.com/vtex-apps/b2b-organizations/assets/5216049/36a94b22-261b-484c-b83f-4ba687dc8b3a">

**After**
<img width="1437" alt="Screenshot 2023-07-13 at 13 30 48" src="https://github.com/vtex-apps/b2b-organizations/assets/5216049/5b3175d4-a442-408c-b884-b979fa2e5dfd">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/jrU2YGXXZOiJO/giphy.gif)
