### PR TITLE
Move creation button to the topbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Move the organization creation button to the topbar
+
 ## [1.24.7] - 2023-07-13
 
 ### Changed

--- a/react/admin/OrganizationsList.tsx
+++ b/react/admin/OrganizationsList.tsx
@@ -9,7 +9,6 @@ import {
   INITIAL_FETCH_LIST_OPTIONS,
   useOrganizationsList,
 } from '../organizations/hooks'
-import CreateOrganizationModal from '../components/CreateOrganizationModal/CreateOrganizationModal'
 
 interface CellRendererProps {
   cellData: unknown
@@ -40,10 +39,6 @@ const OrganizationsList: FunctionComponent = () => {
   const [variableState, setVariables] = useState(INITIAL_FETCH_LIST_OPTIONS)
 
   const { data, loading, refetch } = useOrganizationsList()
-
-  const [newOrganizationModalState, setNewOrganizationModalState] = useState(
-    false
-  )
 
   const getSchema = () => ({
     properties: {
@@ -294,10 +289,6 @@ const OrganizationsList: FunctionComponent = () => {
             onClear: handleInputSearchClear,
             onSubmit: handleInputSearchSubmit,
           },
-          newLine: {
-            label: formatMessage(messages.new),
-            handleCallback: () => setNewOrganizationModalState(true),
-          },
         }}
         sort={{
           sortedBy,
@@ -346,10 +337,6 @@ const OrganizationsList: FunctionComponent = () => {
             },
           },
         }}
-      />
-      <CreateOrganizationModal
-        open={newOrganizationModalState}
-        onOpenChange={open => setNewOrganizationModalState(open)}
       />
     </Fragment>
   )

--- a/react/admin/OrganizationsList.tsx
+++ b/react/admin/OrganizationsList.tsx
@@ -1,36 +1,15 @@
 import type { ChangeEvent, FunctionComponent } from 'react'
-import React, { Fragment, useState, useEffect } from 'react'
-import { useMutation, useQuery } from 'react-apollo'
-import {
-  Button,
-  Checkbox,
-  Input,
-  Modal,
-  Table,
-  Tag,
-  Spinner,
-} from 'vtex.styleguide'
-import { FormattedMessage, useIntl } from 'react-intl'
+import React, { Fragment, useState } from 'react'
+import { Checkbox, Table, Tag } from 'vtex.styleguide'
+import { useIntl } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
-import { useToast } from '@vtex/admin-ui'
-import {
-  AddressContainer,
-  AddressForm,
-  AddressRules,
-  CountrySelector,
-  PostalCodeGetter,
-} from 'vtex.address-form'
-import { StyleguideInput } from 'vtex.address-form/inputs'
-import { addValidation } from 'vtex.address-form/helpers'
 
 import { organizationMessages as messages } from './utils/messages'
-import { getEmptyAddress, isValidAddress } from '../utils/addresses'
-import GET_ORGANIZATIONS from '../graphql/getOrganizations.graphql'
-import GET_LOGISTICS from '../graphql/getLogistics.graphql'
-import CREATE_ORGANIZATION from '../graphql/createOrganization.graphql'
-import { validatePhoneNumber } from '../modules/formValidators'
-import GET_B2B_CUSTOM_FIELDS from '../graphql/getB2BCustomFields.graphql'
-import CustomFieldInput from './OrganizationDetailsCustomField'
+import {
+  INITIAL_FETCH_LIST_OPTIONS,
+  useOrganizationsList,
+} from '../organizations/hooks'
+import CreateOrganizationModal from '../components/CreateOrganizationModal/CreateOrganizationModal'
 
 interface CellRendererProps {
   cellData: unknown
@@ -50,199 +29,21 @@ export const labelTypeByStatusMap: Record<string, string> = {
   'on-hold': 'warning',
 }
 
-const initialState = {
-  status: ['active', 'on-hold', 'inactive'],
-  search: '',
-  page: 1,
-  pageSize: 25,
-  sortOrder: 'ASC',
-  sortedBy: 'name',
-}
-
 const OrganizationsList: FunctionComponent = () => {
   const { formatMessage } = useIntl()
-  const {
-    navigate,
-    culture: { country },
-  } = useRuntime()
-
-  const showToast = useToast()
+  const { navigate } = useRuntime()
 
   const [filterState, setFilterState] = useState({
     filterStatements: [] as FilterStatement[],
   })
 
-  const [loadingState, setLoadingState] = useState(false)
-  const [variableState, setVariables] = useState(initialState)
+  const [variableState, setVariables] = useState(INITIAL_FETCH_LIST_OPTIONS)
+
+  const { data, loading, refetch } = useOrganizationsList()
+
   const [newOrganizationModalState, setNewOrganizationModalState] = useState(
     false
   )
-
-  const [newOrganizationName, setNewOrganizationName] = useState('')
-  const [newCostCenterName, setNewCostCenterName] = useState('')
-  const [newCostCenterPhoneNumber, setNewCostCenterPhoneNumber] = useState('')
-  const [
-    newCostCenterBusinessDocument,
-    setNewCostCenterBusinessDocument,
-  ] = useState('')
-
-  const [
-    newCostCenterStateRegistration,
-    setNewCostCenterStateRegistration,
-  ] = useState('')
-
-  const [newCostCenterAddressState, setNewCostCenterAddressState] = useState(
-    addValidation(getEmptyAddress(country))
-  )
-
-  const { data, loading, refetch } = useQuery(GET_ORGANIZATIONS, {
-    variables: initialState,
-    ssr: false,
-  })
-
-  const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
-  const [createOrganization] = useMutation(CREATE_ORGANIZATION)
-
-  const translateCountries = () => {
-    const { shipsTo = [] } = logisticsData?.logistics ?? {}
-
-    return shipsTo.map((code: string) => ({
-      label: formatMessage({ id: `country.${code}` }),
-      value: code,
-    }))
-  }
-
-  //! CUSTOM FIELDS
-  const {
-    data: defaultCustomFieldsData,
-    loading: defaultCustomFieldsDataLoading,
-  } = useQuery(GET_B2B_CUSTOM_FIELDS, {
-    ssr: false,
-  })
-
-  const [orgCustomFieldsState, setOrgCustomFieldsState] = useState<
-    CustomField[]
-  >([])
-
-  const [
-    costCenterCustomFieldsState,
-    setCostCenterCustomFieldsState,
-  ] = useState<CustomField[]>([])
-
-  useEffect(() => {
-    if (defaultCustomFieldsDataLoading) return
-
-    const organizationFieldsToDisplay = defaultCustomFieldsData?.getB2BSettings.organizationCustomFields.filter(
-      (item: CustomField) => item.useOnRegistration
-    )
-
-    const costCenterFieldsToDisplay = defaultCustomFieldsData?.getB2BSettings.costCenterCustomFields.filter(
-      (item: CustomField) => item.useOnRegistration
-    )
-
-    setOrgCustomFieldsState(organizationFieldsToDisplay)
-    setCostCenterCustomFieldsState(costCenterFieldsToDisplay)
-  }, [defaultCustomFieldsData])
-
-  const handleOrgCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...orgCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setOrgCustomFieldsState(newCustomFields)
-  }
-
-  const handleCostCenterCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...costCenterCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setCostCenterCustomFieldsState(newCustomFields)
-  }
-  //! CUSTOM FIELDS
-
-  const resetNewOrganizationForm = () => {
-    setNewOrganizationName('')
-    setNewCostCenterName('')
-    setNewCostCenterPhoneNumber('')
-    setNewCostCenterBusinessDocument('')
-    setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
-  }
-
-  const handleAddNewOrganization = () => {
-    setLoadingState(true)
-    const newAddress = {
-      addressId: newCostCenterAddressState.addressId.value,
-      addressType: newCostCenterAddressState.addressType.value,
-      city: newCostCenterAddressState.city.value,
-      complement: newCostCenterAddressState.complement.value,
-      country: newCostCenterAddressState.country.value,
-      receiverName: newCostCenterAddressState.receiverName.value,
-      geoCoordinates: newCostCenterAddressState.geoCoordinates.value,
-      neighborhood: newCostCenterAddressState.neighborhood.value,
-      number: newCostCenterAddressState.number.value,
-      postalCode: newCostCenterAddressState.postalCode.value,
-      reference: newCostCenterAddressState.reference.value,
-      state: newCostCenterAddressState.state.value,
-      street: newCostCenterAddressState.street.value,
-      addressQuery: newCostCenterAddressState.addressQuery.value,
-    }
-
-    const variables = {
-      input: {
-        name: newOrganizationName,
-        customFields: orgCustomFieldsState,
-        defaultCostCenter: {
-          name: newCostCenterName,
-          address: newAddress,
-          phoneNumber: newCostCenterPhoneNumber,
-          businessDocument: newCostCenterBusinessDocument,
-          customFields: costCenterCustomFieldsState,
-          stateRegistration: newCostCenterStateRegistration,
-        },
-      },
-    }
-
-    createOrganization({ variables })
-      .then(() => {
-        setNewOrganizationModalState(false)
-        setLoadingState(false)
-        resetNewOrganizationForm()
-        showToast({
-          variant: 'positive',
-          message: formatMessage(messages.toastAddOrgSuccess),
-        })
-        refetch(initialState)
-      })
-      .catch(error => {
-        setNewOrganizationModalState(false)
-        setLoadingState(false)
-        console.error(error)
-        showToast({
-          variant: 'critical',
-          message: formatMessage(messages.toastAddOrgFailure),
-        })
-      })
-  }
-
-  const handleNewCostCenterAddressChange = (
-    changedAddress: AddressFormFields
-  ) => {
-    const curAddress = newCostCenterAddressState
-
-    const newAddress = { ...curAddress, ...changedAddress }
-
-    setNewCostCenterAddressState(newAddress)
-  }
-
-  const handleCloseModal = () => {
-    setNewOrganizationModalState(false)
-    resetNewOrganizationForm()
-  }
 
   const getSchema = () => ({
     properties: {
@@ -546,173 +347,10 @@ const OrganizationsList: FunctionComponent = () => {
           },
         }}
       />
-
-      <Modal
-        centered
-        bottomBar={
-          <div className="nowrap">
-            <span className="mr4">
-              <Button
-                variation="tertiary"
-                onClick={() => handleCloseModal()}
-                disabled={loadingState}
-              >
-                {formatMessage(messages.cancel)}
-              </Button>
-            </span>
-            <span>
-              <Button
-                variation="primary"
-                onClick={() => handleAddNewOrganization()}
-                isLoading={loadingState}
-                disabled={
-                  !newOrganizationName ||
-                  !newCostCenterName ||
-                  !isValidAddress(newCostCenterAddressState) ||
-                  (newCostCenterPhoneNumber &&
-                    !validatePhoneNumber(newCostCenterPhoneNumber))
-                }
-              >
-                {formatMessage(messages.add)}
-              </Button>
-            </span>
-          </div>
-        }
-        isOpen={newOrganizationModalState}
-        onClose={() => handleCloseModal()}
-        closeOnOverlayClick={false}
-      >
-        <p className="f3 f1-ns fw3 gray">
-          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization" />
-        </p>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.organizationName)}
-            value={newOrganizationName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewOrganizationName(e.target.value)
-            }}
-            required
-          />
-        </div>
-        {/* //! Custom fields */}
-        {defaultCustomFieldsDataLoading ? (
-          <div className="mb5">
-            <Spinner />
-          </div>
-        ) : (
-          orgCustomFieldsState?.map(
-            (customField: CustomField, index: number) => {
-              return (
-                <CustomFieldInput
-                  key={`${customField.name}`}
-                  index={index}
-                  handleUpdate={handleOrgCustomFieldsUpdate}
-                  customField={customField}
-                />
-              )
-            }
-          )
-        )}
-
-        {/* //! Custom fields */}
-        <div className="w-100 mv6">
-          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization.default-costCenter.helpText" />
-        </div>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.defaultCostCenterName)}
-            value={newCostCenterName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterName(e.target.value)
-            }}
-            required
-          />
-        </div>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.phoneNumber)}
-            value={newCostCenterPhoneNumber}
-            error={
-              newCostCenterPhoneNumber &&
-              !validatePhoneNumber(newCostCenterPhoneNumber)
-            }
-            helpText={formatMessage(messages.phoneNumberHelp)}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterPhoneNumber(e.target.value)
-            }}
-          />
-        </div>
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.businessDocument)}
-            value={newCostCenterBusinessDocument}
-            helpText={formatMessage(messages.businessDocumentHelp)}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterBusinessDocument(e.target.value)
-            }}
-          />
-        </div>
-        {/* //! Custom fields */}
-        {defaultCustomFieldsDataLoading ? (
-          <div className="mb5 flex flex-column">
-            <Spinner />
-          </div>
-        ) : (
-          <>
-            {costCenterCustomFieldsState?.map(
-              (customField: CustomField, index: number) => {
-                return (
-                  <CustomFieldInput
-                    key={`${customField.name}`}
-                    index={index}
-                    handleUpdate={handleCostCenterCustomFieldsUpdate}
-                    customField={customField}
-                  />
-                )
-              }
-            )}
-          </>
-        )}
-        {/* //! Custom fields */}
-        <div className="w-100 mv6">
-          <Input
-            size="large"
-            label={formatMessage(messages.stateRegistration)}
-            value={newCostCenterStateRegistration}
-            helpText={formatMessage(messages.stateRegistrationHelp)}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setNewCostCenterStateRegistration(e.target.value)
-            }}
-          />
-        </div>
-        <AddressRules
-          country={newCostCenterAddressState?.country?.value}
-          shouldUseIOFetching
-          useGeolocation={false}
-        >
-          <AddressContainer
-            address={newCostCenterAddressState}
-            Input={StyleguideInput}
-            onChangeAddress={handleNewCostCenterAddressChange}
-            autoCompletePostalCode
-          >
-            <CountrySelector shipsTo={translateCountries()} />
-
-            <PostalCodeGetter />
-
-            <AddressForm
-              Input={StyleguideInput}
-              omitAutoCompletedFields={false}
-              omitPostalCodeFields
-            />
-          </AddressContainer>
-        </AddressRules>
-      </Modal>
+      <CreateOrganizationModal
+        open={newOrganizationModalState}
+        onOpenChange={open => setNewOrganizationModalState(open)}
+      />
     </Fragment>
   )
 }

--- a/react/admin/OrganizationsTable.tsx
+++ b/react/admin/OrganizationsTable.tsx
@@ -9,6 +9,7 @@ import {
   Tab,
   PageContent,
   useTabState,
+  PageHeaderActions,
 } from '@vtex/admin-ui'
 import { useIntl } from 'react-intl'
 import { HashRouter, Switch, Route } from 'react-router-dom'
@@ -24,6 +25,7 @@ import OrganizationSettings from './OrganizationSettings'
 import useHashRouter from './OrganizationDetails/useHashRouter'
 import OrganizationCustomFields from './CustomFields'
 import CheckCustomerSchema from '../components/CheckCustomerSchema'
+import CreateOrganizationButton from '../components/CreateOrganizationButton/CreateOrganizationButton'
 
 const SESSION_STORAGE_KEY = 'organization-tab'
 
@@ -45,6 +47,14 @@ const OrganizationsTable = () => {
             <PageHeaderTitle>
               {formatMessage(messages.tablePageTitle)}
             </PageHeaderTitle>
+
+            <PageHeaderActions>
+              <Route
+                path="/organizations"
+                exact
+                component={CreateOrganizationButton}
+              />
+            </PageHeaderActions>
           </PageHeaderTop>
           <PageHeaderBottom>
             <TabList state={tabsState}>

--- a/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
+++ b/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+import { useIntl } from 'react-intl'
+import { PageHeaderButton } from '@vtex/admin-ui'
+
+import CreateOrganizationModal from '../CreateOrganizationModal'
+import { organizationMessages as messages } from '../../admin/utils/messages'
+
+const CreateOrganizationButton = () => {
+  const { formatMessage } = useIntl()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <PageHeaderButton onClick={() => setOpen(true)}>
+        {formatMessage(messages.new)}
+      </PageHeaderButton>
+      <CreateOrganizationModal open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+
+export default CreateOrganizationButton

--- a/react/components/CreateOrganizationButton/index.tsx
+++ b/react/components/CreateOrganizationButton/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CreateOrganizationButton'

--- a/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
+++ b/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
@@ -60,7 +60,7 @@ const CreateOrganizationModal: React.FC<Props> = ({ open, onOpenChange }) => {
 
   const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
   const [createOrganization] = useMutation(CREATE_ORGANIZATION)
-  const { refetch, loading } = useOrganizationsList()
+  const { refetch } = useOrganizationsList()
 
   const translateCountries = () => {
     const { shipsTo = [] } = logisticsData?.logistics ?? {}

--- a/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
+++ b/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useMutation, useQuery } from 'react-apollo'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { useToast } from '@vtex/admin-ui'
-import { Button, Input, Modal, Spinner } from 'vtex.styleguide'
+import { Button, Input, Modal } from 'vtex.styleguide'
 import {
   AddressContainer,
   AddressForm,
@@ -16,7 +16,6 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import { getEmptyAddress, isValidAddress } from '../../utils/addresses'
 import { validatePhoneNumber } from '../../modules/formValidators'
-import CustomFieldInput from '../../admin/OrganizationDetailsCustomField'
 import { organizationMessages as messages } from '../../admin/utils/messages'
 import GET_LOGISTICS from '../../graphql/getLogistics.graphql'
 import CREATE_ORGANIZATION from '../../graphql/createOrganization.graphql'
@@ -25,6 +24,7 @@ import {
   INITIAL_FETCH_LIST_OPTIONS,
   useOrganizationsList,
 } from '../../organizations/hooks'
+import CustomFieldInputList from '../CustomFieldInputList/CustomFieldInputList'
 
 interface Props {
   open: boolean
@@ -102,26 +102,6 @@ const CreateOrganizationModal: React.FC<Props> = ({ open, onOpenChange }) => {
     setOrgCustomFieldsState(organizationFieldsToDisplay)
     setCostCenterCustomFieldsState(costCenterFieldsToDisplay)
   }, [defaultCustomFieldsData])
-
-  const handleOrgCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...orgCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setOrgCustomFieldsState(newCustomFields)
-  }
-
-  const handleCostCenterCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...costCenterCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setCostCenterCustomFieldsState(newCustomFields)
-  }
   //! CUSTOM FIELDS
 
   const resetNewOrganizationForm = () => {
@@ -254,27 +234,12 @@ const CreateOrganizationModal: React.FC<Props> = ({ open, onOpenChange }) => {
             required
           />
         </div>
-        {/* //! Custom fields */}
-        {defaultCustomFieldsDataLoading ? (
-          <div className="mb5">
-            <Spinner />
-          </div>
-        ) : (
-          orgCustomFieldsState?.map(
-            (customField: CustomField, index: number) => {
-              return (
-                <CustomFieldInput
-                  key={`${customField.name}`}
-                  index={index}
-                  handleUpdate={handleOrgCustomFieldsUpdate}
-                  customField={customField}
-                />
-              )
-            }
-          )
-        )}
-
-        {/* //! Custom fields */}
+        <CustomFieldInputList
+          customFields={
+            defaultCustomFieldsDataLoading ? null : orgCustomFieldsState
+          }
+          onChange={setOrgCustomFieldsState}
+        />
         <div className="w-100 mv6">
           <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization.default-costCenter.helpText" />
         </div>
@@ -315,28 +280,12 @@ const CreateOrganizationModal: React.FC<Props> = ({ open, onOpenChange }) => {
             }}
           />
         </div>
-        {/* //! Custom fields */}
-        {defaultCustomFieldsDataLoading ? (
-          <div className="mb5 flex flex-column">
-            <Spinner />
-          </div>
-        ) : (
-          <>
-            {costCenterCustomFieldsState?.map(
-              (customField: CustomField, index: number) => {
-                return (
-                  <CustomFieldInput
-                    key={`${customField.name}`}
-                    index={index}
-                    handleUpdate={handleCostCenterCustomFieldsUpdate}
-                    customField={customField}
-                  />
-                )
-              }
-            )}
-          </>
-        )}
-        {/* //! Custom fields */}
+        <CustomFieldInputList
+          customFields={
+            defaultCustomFieldsDataLoading ? null : costCenterCustomFieldsState
+          }
+          onChange={setCostCenterCustomFieldsState}
+        />
         <div className="w-100 mv6">
           <Input
             size="large"

--- a/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
+++ b/react/components/CreateOrganizationModal/CreateOrganizationModal.tsx
@@ -1,0 +1,378 @@
+import React, { useEffect, useState } from 'react'
+import { useMutation, useQuery } from 'react-apollo'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { useToast } from '@vtex/admin-ui'
+import { Button, Input, Modal, Spinner } from 'vtex.styleguide'
+import {
+  AddressContainer,
+  AddressForm,
+  AddressRules,
+  CountrySelector,
+  PostalCodeGetter,
+} from 'vtex.address-form'
+import { StyleguideInput } from 'vtex.address-form/inputs'
+import { addValidation } from 'vtex.address-form/helpers'
+import { useRuntime } from 'vtex.render-runtime'
+
+import { getEmptyAddress, isValidAddress } from '../../utils/addresses'
+import { validatePhoneNumber } from '../../modules/formValidators'
+import CustomFieldInput from '../../admin/OrganizationDetailsCustomField'
+import { organizationMessages as messages } from '../../admin/utils/messages'
+import GET_LOGISTICS from '../../graphql/getLogistics.graphql'
+import CREATE_ORGANIZATION from '../../graphql/createOrganization.graphql'
+import GET_B2B_CUSTOM_FIELDS from '../../graphql/getB2BCustomFields.graphql'
+import {
+  INITIAL_FETCH_LIST_OPTIONS,
+  useOrganizationsList,
+} from '../../organizations/hooks'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const CreateOrganizationModal: React.FC<Props> = ({ open, onOpenChange }) => {
+  const { formatMessage } = useIntl()
+  const {
+    culture: { country },
+  } = useRuntime()
+
+  const showToast = useToast()
+
+  const [loadingState, setLoadingState] = useState(false)
+
+  const [newOrganizationName, setNewOrganizationName] = useState('')
+  const [newCostCenterName, setNewCostCenterName] = useState('')
+  const [newCostCenterPhoneNumber, setNewCostCenterPhoneNumber] = useState('')
+  const [
+    newCostCenterBusinessDocument,
+    setNewCostCenterBusinessDocument,
+  ] = useState('')
+
+  const [
+    newCostCenterStateRegistration,
+    setNewCostCenterStateRegistration,
+  ] = useState('')
+
+  const [newCostCenterAddressState, setNewCostCenterAddressState] = useState(
+    addValidation(getEmptyAddress(country))
+  )
+
+  const { data: logisticsData } = useQuery(GET_LOGISTICS, { ssr: false })
+  const [createOrganization] = useMutation(CREATE_ORGANIZATION)
+  const { refetch, loading } = useOrganizationsList()
+
+  const translateCountries = () => {
+    const { shipsTo = [] } = logisticsData?.logistics ?? {}
+
+    return shipsTo.map((code: string) => ({
+      label: formatMessage({ id: `country.${code}` }),
+      value: code,
+    }))
+  }
+
+  //! CUSTOM FIELDS
+  const {
+    data: defaultCustomFieldsData,
+    loading: defaultCustomFieldsDataLoading,
+  } = useQuery(GET_B2B_CUSTOM_FIELDS, {
+    ssr: false,
+  })
+
+  const [orgCustomFieldsState, setOrgCustomFieldsState] = useState<
+    CustomField[]
+  >([])
+
+  const [
+    costCenterCustomFieldsState,
+    setCostCenterCustomFieldsState,
+  ] = useState<CustomField[]>([])
+
+  useEffect(() => {
+    if (defaultCustomFieldsDataLoading) return
+
+    const organizationFieldsToDisplay = defaultCustomFieldsData?.getB2BSettings.organizationCustomFields.filter(
+      (item: CustomField) => item.useOnRegistration
+    )
+
+    const costCenterFieldsToDisplay = defaultCustomFieldsData?.getB2BSettings.costCenterCustomFields.filter(
+      (item: CustomField) => item.useOnRegistration
+    )
+
+    setOrgCustomFieldsState(organizationFieldsToDisplay)
+    setCostCenterCustomFieldsState(costCenterFieldsToDisplay)
+  }, [defaultCustomFieldsData])
+
+  const handleOrgCustomFieldsUpdate = (
+    index: number,
+    customField: CustomField
+  ) => {
+    const newCustomFields = [...orgCustomFieldsState]
+
+    newCustomFields[index] = customField
+    setOrgCustomFieldsState(newCustomFields)
+  }
+
+  const handleCostCenterCustomFieldsUpdate = (
+    index: number,
+    customField: CustomField
+  ) => {
+    const newCustomFields = [...costCenterCustomFieldsState]
+
+    newCustomFields[index] = customField
+    setCostCenterCustomFieldsState(newCustomFields)
+  }
+  //! CUSTOM FIELDS
+
+  const resetNewOrganizationForm = () => {
+    setNewOrganizationName('')
+    setNewCostCenterName('')
+    setNewCostCenterPhoneNumber('')
+    setNewCostCenterBusinessDocument('')
+    setNewCostCenterAddressState(addValidation(getEmptyAddress(country)))
+  }
+
+  const handleAddNewOrganization = () => {
+    setLoadingState(true)
+    const newAddress = {
+      addressId: newCostCenterAddressState.addressId.value,
+      addressType: newCostCenterAddressState.addressType.value,
+      city: newCostCenterAddressState.city.value,
+      complement: newCostCenterAddressState.complement.value,
+      country: newCostCenterAddressState.country.value,
+      receiverName: newCostCenterAddressState.receiverName.value,
+      geoCoordinates: newCostCenterAddressState.geoCoordinates.value,
+      neighborhood: newCostCenterAddressState.neighborhood.value,
+      number: newCostCenterAddressState.number.value,
+      postalCode: newCostCenterAddressState.postalCode.value,
+      reference: newCostCenterAddressState.reference.value,
+      state: newCostCenterAddressState.state.value,
+      street: newCostCenterAddressState.street.value,
+      addressQuery: newCostCenterAddressState.addressQuery.value,
+    }
+
+    const variables = {
+      input: {
+        name: newOrganizationName,
+        customFields: orgCustomFieldsState,
+        defaultCostCenter: {
+          name: newCostCenterName,
+          address: newAddress,
+          phoneNumber: newCostCenterPhoneNumber,
+          businessDocument: newCostCenterBusinessDocument,
+          customFields: costCenterCustomFieldsState,
+          stateRegistration: newCostCenterStateRegistration,
+        },
+      },
+    }
+
+    createOrganization({ variables })
+      .then(() => {
+        onOpenChange(false)
+        setLoadingState(false)
+        resetNewOrganizationForm()
+        showToast({
+          variant: 'positive',
+          message: formatMessage(messages.toastAddOrgSuccess),
+        })
+        refetch(INITIAL_FETCH_LIST_OPTIONS)
+      })
+      .catch(error => {
+        onOpenChange(false)
+        setLoadingState(false)
+        console.error(error)
+        showToast({
+          variant: 'critical',
+          message: formatMessage(messages.toastAddOrgFailure),
+        })
+      })
+  }
+
+  const handleNewCostCenterAddressChange = (
+    changedAddress: AddressFormFields
+  ) => {
+    const curAddress = newCostCenterAddressState
+
+    const newAddress = { ...curAddress, ...changedAddress }
+
+    setNewCostCenterAddressState(newAddress)
+  }
+
+  const handleCloseModal = () => {
+    onOpenChange(false)
+    resetNewOrganizationForm()
+  }
+
+  return (
+    <>
+      <Modal
+        centered
+        bottomBar={
+          <div className="nowrap">
+            <span className="mr4">
+              <Button
+                variation="tertiary"
+                onClick={() => handleCloseModal()}
+                disabled={loadingState}
+              >
+                {formatMessage(messages.cancel)}
+              </Button>
+            </span>
+            <span>
+              <Button
+                variation="primary"
+                onClick={() => handleAddNewOrganization()}
+                isLoading={loadingState}
+                disabled={
+                  !newOrganizationName ||
+                  !newCostCenterName ||
+                  !isValidAddress(newCostCenterAddressState) ||
+                  (newCostCenterPhoneNumber &&
+                    !validatePhoneNumber(newCostCenterPhoneNumber))
+                }
+              >
+                {formatMessage(messages.add)}
+              </Button>
+            </span>
+          </div>
+        }
+        isOpen={open}
+        onClose={() => handleCloseModal()}
+        closeOnOverlayClick={false}
+      >
+        <p className="f3 f1-ns fw3 gray">
+          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization" />
+        </p>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.organizationName)}
+            value={newOrganizationName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewOrganizationName(e.target.value)
+            }}
+            required
+          />
+        </div>
+        {/* //! Custom fields */}
+        {defaultCustomFieldsDataLoading ? (
+          <div className="mb5">
+            <Spinner />
+          </div>
+        ) : (
+          orgCustomFieldsState?.map(
+            (customField: CustomField, index: number) => {
+              return (
+                <CustomFieldInput
+                  key={`${customField.name}`}
+                  index={index}
+                  handleUpdate={handleOrgCustomFieldsUpdate}
+                  customField={customField}
+                />
+              )
+            }
+          )
+        )}
+
+        {/* //! Custom fields */}
+        <div className="w-100 mv6">
+          <FormattedMessage id="admin/b2b-organizations.organizations-admin.add-organization.default-costCenter.helpText" />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.defaultCostCenterName)}
+            value={newCostCenterName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterName(e.target.value)
+            }}
+            required
+          />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.phoneNumber)}
+            value={newCostCenterPhoneNumber}
+            error={
+              newCostCenterPhoneNumber &&
+              !validatePhoneNumber(newCostCenterPhoneNumber)
+            }
+            helpText={formatMessage(messages.phoneNumberHelp)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterPhoneNumber(e.target.value)
+            }}
+          />
+        </div>
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.businessDocument)}
+            value={newCostCenterBusinessDocument}
+            helpText={formatMessage(messages.businessDocumentHelp)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterBusinessDocument(e.target.value)
+            }}
+          />
+        </div>
+        {/* //! Custom fields */}
+        {defaultCustomFieldsDataLoading ? (
+          <div className="mb5 flex flex-column">
+            <Spinner />
+          </div>
+        ) : (
+          <>
+            {costCenterCustomFieldsState?.map(
+              (customField: CustomField, index: number) => {
+                return (
+                  <CustomFieldInput
+                    key={`${customField.name}`}
+                    index={index}
+                    handleUpdate={handleCostCenterCustomFieldsUpdate}
+                    customField={customField}
+                  />
+                )
+              }
+            )}
+          </>
+        )}
+        {/* //! Custom fields */}
+        <div className="w-100 mv6">
+          <Input
+            size="large"
+            label={formatMessage(messages.stateRegistration)}
+            value={newCostCenterStateRegistration}
+            helpText={formatMessage(messages.stateRegistrationHelp)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setNewCostCenterStateRegistration(e.target.value)
+            }}
+          />
+        </div>
+        <AddressRules
+          country={newCostCenterAddressState?.country?.value}
+          shouldUseIOFetching
+          useGeolocation={false}
+        >
+          <AddressContainer
+            address={newCostCenterAddressState}
+            Input={StyleguideInput}
+            onChangeAddress={handleNewCostCenterAddressChange}
+            autoCompletePostalCode
+          >
+            <CountrySelector shipsTo={translateCountries()} />
+
+            <PostalCodeGetter />
+
+            <AddressForm
+              Input={StyleguideInput}
+              omitAutoCompletedFields={false}
+              omitPostalCodeFields
+            />
+          </AddressContainer>
+        </AddressRules>
+      </Modal>
+    </>
+  )
+}
+
+export default CreateOrganizationModal

--- a/react/components/CreateOrganizationModal/index.tsx
+++ b/react/components/CreateOrganizationModal/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './CreateOrganization'
+export { default } from './CreateOrganizationModal'

--- a/react/components/CreateOrganizationModal/index.tsx
+++ b/react/components/CreateOrganizationModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CreateOrganization'

--- a/react/components/CustomFieldInputList/CustomFieldInputList.tsx
+++ b/react/components/CustomFieldInputList/CustomFieldInputList.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Spinner } from 'vtex.styleguide'
+
+import CustomFieldInput from '../../admin/OrganizationDetailsCustomField'
+
+interface Props {
+  customFields: CustomField[] | null
+  onChange: (customFields: CustomField[]) => void
+}
+
+const CustomFieldInputList: React.FC<Props> = ({ customFields, onChange }) => {
+  const isLoading = !customFields
+
+  const handleUpdate = (index: number, customField: CustomField) => {
+    if (!customFields) return
+
+    const newCustomFields = [...customFields]
+
+    newCustomFields[index] = customField
+    onChange(newCustomFields)
+  }
+
+  return (
+    <>
+      {isLoading ? (
+        <div className="mb5">
+          <Spinner />
+        </div>
+      ) : (
+        customFields?.map((customField: CustomField, index: number) => {
+          return (
+            <CustomFieldInput
+              key={`${customField.name}`}
+              index={index}
+              handleUpdate={handleUpdate}
+              customField={customField}
+            />
+          )
+        })
+      )}
+    </>
+  )
+}
+
+export default CustomFieldInputList

--- a/react/components/CustomFieldInputList/index.tsx
+++ b/react/components/CustomFieldInputList/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CustomFieldInputList'

--- a/react/components/RequestOrganizationForm.tsx
+++ b/react/components/RequestOrganizationForm.tsx
@@ -35,7 +35,7 @@ import GET_ORGANIZATION_REQUEST from '../graphql/getOrganizationRequest.graphql'
 import GET_LOGISTICS from '../graphql/getLogistics.graphql'
 import GET_B2B_CUSTOM_FIELDS from '../graphql/getB2BCustomFields.graphql'
 import IMPERSONATE_USER from '../graphql/impersonateUser.graphql'
-import CustomFieldInput from '../admin/OrganizationDetailsCustomField'
+import CustomFieldInputList from './CustomFieldInputList/CustomFieldInputList'
 
 const localStore = storageFactory(() => localStorage)
 let requestId = localStore.getItem('b2b-organizations_orgRequestId') ?? ''
@@ -208,25 +208,6 @@ const RequestOrganizationForm: FC = () => {
     setCostCenterCustomFieldsState(costCenterFieldsToDisplay)
   }, [defaultCustomFieldsData])
 
-  const handleOrgCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...orgCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setOrgCustomFieldsState(newCustomFields)
-  }
-
-  const handleCostCenterCustomFieldsUpdate = (
-    index: number,
-    customField: CustomField
-  ) => {
-    const newCustomFields = [...costCenterCustomFieldsState]
-
-    newCustomFields[index] = customField
-    setCostCenterCustomFieldsState(newCustomFields)
-  }
   //! CUSTOM FIELDS
 
   const handleImpersonation = () => {
@@ -442,27 +423,12 @@ const RequestOrganizationForm: FC = () => {
               }}
             />
           </div>
-          {/* //! Custom fields */}
-          {defaultCustomFieldsDataLoading ? (
-            <div className="mb5">
-              <Spinner />
-            </div>
-          ) : (
-            orgCustomFieldsState?.map(
-              (customField: CustomField, index: number) => {
-                return (
-                  <CustomFieldInput
-                    key={`${customField.name}`}
-                    index={index}
-                    handleUpdate={handleOrgCustomFieldsUpdate}
-                    customField={customField}
-                  />
-                )
-              }
-            )
-          )}
-
-          {/* //! Custom fields */}
+          <CustomFieldInputList
+            customFields={
+              defaultCustomFieldsDataLoading ? null : orgCustomFieldsState
+            }
+            onChange={setOrgCustomFieldsState}
+          />
         </PageBlock>
         <PageBlock
           variation="full"
@@ -574,28 +540,14 @@ const RequestOrganizationForm: FC = () => {
               }}
             />
           </div>
-          {/* //! Custom fields */}
-          {defaultCustomFieldsDataLoading ? (
-            <div className="mb5 flex flex-column">
-              <Spinner />
-            </div>
-          ) : (
-            <>
-              {costCenterCustomFieldsState?.map(
-                (customField: CustomField, index: number) => {
-                  return (
-                    <CustomFieldInput
-                      key={`${customField.name}`}
-                      index={index}
-                      handleUpdate={handleCostCenterCustomFieldsUpdate}
-                      customField={customField}
-                    />
-                  )
-                }
-              )}
-            </>
-          )}
-          {/* //! Custom fields */}
+          <CustomFieldInputList
+            customFields={
+              defaultCustomFieldsDataLoading
+                ? null
+                : costCenterCustomFieldsState
+            }
+            onChange={setCostCenterCustomFieldsState}
+          />
           <div
             className={`${handles.newOrganizationInput} mb5 flex flex-column`}
           >

--- a/react/organizations/hooks.ts
+++ b/react/organizations/hooks.ts
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-apollo'
+
+import GET_ORGANIZATIONS from '../graphql/getOrganizations.graphql'
+
+export const INITIAL_FETCH_LIST_OPTIONS = {
+  status: ['active', 'on-hold', 'inactive'],
+  search: '',
+  page: 1,
+  pageSize: 25,
+  sortOrder: 'ASC',
+  sortedBy: 'name',
+}
+
+export const useOrganizationsList = () => {
+  return useQuery(GET_ORGANIZATIONS, {
+    variables: INITIAL_FETCH_LIST_OPTIONS,
+    ssr: false,
+  })
+}


### PR DESCRIPTION
#### What problem is this solving?

This is moving the button for creation organizations to the topbar, which is the new Admin standard for these page actions.

The change seems simple, but it required a lot more code than the previous and bigger visual change of my previous PR (related to updating layout + tabs). I didn't actually change much of the code though, I just refactored a big part of it so I could split the creation button + modal from the organizations list, since they were within the same file. I'll comment inline to further explain the changes.

#### How to test it?

Create a few organizations in the workspace below and check that they're being correctly created as before.

Also, if the new organization's name is such that it would show up at the top of the initial organizations table on the page, it correctly shows up there just like before. To test this, create a new organization that starts with the letter A for example, and check that it shows up on the table after the operation is successful.

[Workspace](https://mairamodal--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations/#/organizations)

#### Screenshots or example usage:

**Before**
<img width="1437" alt="Screenshot 2023-07-13 at 13 30 48" src="https://github.com/vtex-apps/b2b-organizations/assets/5216049/aa9fd201-5abf-4dd0-8ef4-98fd0b3760d4">

**After**
<img width="1440" alt="Screenshot 2023-07-14 at 11 56 16" src="https://github.com/vtex-apps/b2b-organizations/assets/5216049/687d15ee-fb5b-45bf-8f50-7c3defdd0df0">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHdibG0xeHFyZTZwc2p1MWVwanR6ajBhOXF2ajB6azZsa3lyOXl4eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HlGmv4WqldO9c5y/giphy.gif)
