### PR TITLE
Change Team Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added metrics to Impersonate events
 - Added metrics to Stop Impersonating events
+- Added metrics to change team events
 
 ## [1.25.0] - 2023-07-24
 

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -264,30 +264,19 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
           costId: organizationsState.currentCostCenter,
         },
       })
+
+      const metricParams: ChangeTeamParams = {
+        sessionResponse,
+        ...organizationsState,
+      }
+
+      sendChangeTeamMetric(metricParams)
     } catch (error) {
       setErrorOrganization(true)
     } finally {
       setLoadingState(false)
     }
 
-    const {
-      currentCostCenter: costCenterId,
-      currentOrganization: orgId,
-      currentRoleName: userRole,
-    } = organizationsState
-
-    const profile = sessionResponse?.namespaces?.profile
-
-    const metricParams: ChangeTeamParams = {
-      account: sessionResponse?.namespaces?.account?.accountName?.value,
-      userId: profile?.id.value,
-      userRole,
-      userEmail: profile?.email.value,
-      orgId,
-      costCenterId,
-    }
-
-    sendChangeTeamMetric(metricParams)
     window.location.reload()
   }
 

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -28,6 +28,8 @@ import {
 } from '../utils/constants'
 import '../css/user-widget.css'
 import { sendStopImpersonateMetric } from '../utils/metrics/impersonate'
+import type { ChangeTeamParams } from '../utils/metrics/changeTeam'
+import { sendChangeTeamMetric } from '../utils/metrics/changeTeam'
 
 const CSS_HANDLES = [
   'userWidgetContainer',
@@ -291,6 +293,24 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
       setLoadingState(false)
     }
 
+    const {
+      currentCostCenter: costCenterId,
+      currentOrganization: orgId,
+      currentRoleName: userRole,
+    } = organizationsState
+
+    const profile = sessionResponse?.namespaces?.profile
+
+    const metricParams: ChangeTeamParams = {
+      account: sessionResponse?.namespaces?.account?.accountName?.value,
+      userId: profile?.id.value,
+      userRole,
+      userEmail: profile?.email.value,
+      orgId,
+      costCenterId,
+    }
+
+    sendChangeTeamMetric(metricParams)
     window.location.reload()
   }
 

--- a/react/utils/metrics/changeTeam.ts
+++ b/react/utils/metrics/changeTeam.ts
@@ -1,0 +1,49 @@
+import type { Metric } from './metrics'
+import { sendMetric } from './metrics'
+
+type ChangeTeamFieldsMetric = {
+  date: string
+  user_id: string
+  user_role: string
+  user_email: string
+  org_id: string
+  cost_center_id: string
+}
+
+type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }
+
+export type ChangeTeamParams = {
+  account: string
+  userId: string
+  userRole: string
+  userEmail: string
+  orgId: string
+  costCenterId: string
+}
+
+const buildMetric = (metricParams: ChangeTeamParams): ChangeTeamMetric => {
+  return {
+    name: 'b2b-suite-buyerorg-data' as const,
+    account: metricParams.account,
+    kind: 'change-team-ui-event',
+    description: 'User change team/organization - UI',
+    fields: {
+      date: new Date().toISOString(),
+      user_id: metricParams.userId,
+      user_role: metricParams.userRole,
+      user_email: metricParams.userEmail,
+      org_id: metricParams.orgId,
+      cost_center_id: metricParams.costCenterId,
+    },
+  }
+}
+
+export const sendChangeTeamMetric = async (metricParams: ChangeTeamParams) => {
+  try {
+    const metric: ChangeTeamMetric = buildMetric(metricParams)
+
+    await sendMetric(metric)
+  } catch (error) {
+    console.warn('Unable to log metrics', error)
+  }
+}

--- a/react/utils/metrics/changeTeam.ts
+++ b/react/utils/metrics/changeTeam.ts
@@ -1,9 +1,8 @@
-import type { Metric } from './metrics'
+import type { Metric, SessionResponseParam } from './metrics'
 import { sendMetric } from './metrics'
 
 type ChangeTeamFieldsMetric = {
   date: string
-  user_id: string
   user_role: string
   user_email: string
   org_id: string
@@ -12,28 +11,36 @@ type ChangeTeamFieldsMetric = {
 
 type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }
 
+export type StopImpersonateMetricParams = {
+  sessionResponse: SessionResponseParam
+  currentCostCenter: string
+  costCenterInput: string
+  currentOrganization: string
+  organizationInput: string
+  email: string
+}
+
 export type ChangeTeamParams = {
-  account: string
-  userId: string
-  userRole: string
-  userEmail: string
-  orgId: string
-  costCenterId: string
+  sessionResponse: SessionResponseParam
+  currentRoleName: string
+  currentOrganization: string
+  currentCostCenter: string
 }
 
 const buildMetric = (metricParams: ChangeTeamParams): ChangeTeamMetric => {
   return {
     name: 'b2b-suite-buyerorg-data' as const,
-    account: metricParams.account,
+    account:
+      metricParams.sessionResponse?.namespaces?.account?.accountName?.value,
     kind: 'change-team-ui-event',
     description: 'User change team/organization - UI',
     fields: {
       date: new Date().toISOString(),
-      user_id: metricParams.userId,
-      user_role: metricParams.userRole,
-      user_email: metricParams.userEmail,
-      org_id: metricParams.orgId,
-      cost_center_id: metricParams.costCenterId,
+      user_role: metricParams.currentRoleName,
+      user_email:
+        metricParams.sessionResponse?.namespaces?.profile?.email?.value,
+      org_id: metricParams.currentOrganization,
+      cost_center_id: metricParams.currentCostCenter,
     },
   }
 }

--- a/react/utils/metrics/impersonate.ts
+++ b/react/utils/metrics/impersonate.ts
@@ -1,6 +1,6 @@
 import type { B2BUserSimple } from '../../components/OrganizationUsersTable'
 import { getSession } from '../../modules/session'
-import type { Metric } from './metrics'
+import type { Metric, SessionResponseParam } from './metrics'
 import { sendMetric } from './metrics'
 
 type ImpersonatePerson = {
@@ -39,26 +39,6 @@ export type StopImpersonateMetricParams = {
   currentOrganization: string
   organizationInput: string
   email: string
-}
-
-type SessionResponseParam = {
-  namespaces: {
-    account: {
-      accountName: {
-        value: string
-      }
-    }
-    profile: {
-      email: {
-        value: string
-      }
-    }
-    authentication: {
-      storeUserEmail: {
-        value: string
-      }
-    }
-  }
 }
 
 const buildImpersonateMetric = async (

--- a/react/utils/metrics/metrics.ts
+++ b/react/utils/metrics/metrics.ts
@@ -29,3 +29,23 @@ export const sendMetric = async (metric: Metric) => {
     console.warn('Unable to log metrics', error)
   }
 }
+
+export type SessionResponseParam = {
+  namespaces: {
+    account: {
+      accountName: {
+        value: string
+      }
+    }
+    profile: {
+      email: {
+        value: string
+      }
+    }
+    authentication: {
+      storeUserEmail: {
+        value: string
+      }
+    }
+  }
+}

--- a/react/utils/metrics/metrics.ts
+++ b/react/utils/metrics/metrics.ts
@@ -12,10 +12,15 @@ type StopImpersonateMetric = {
   description: 'Stop Impersonate User Action - UI'
 }
 
+export type ChangeTeamMetric = {
+  kind: 'change-team-ui-event'
+  description: 'User change team/organization - UI'
+}
+
 export type Metric = {
   name: 'b2b-suite-buyerorg-data'
   account: string
-} & (ImpersonateMetric | StopImpersonateMetric)
+} & (ImpersonateMetric | StopImpersonateMetric | ChangeTeamMetric)
 
 export const sendMetric = async (metric: Metric) => {
   try {


### PR DESCRIPTION
#### What problem is this solving?

Send to analytics events related to Change Team.

#### How to test it?

Logged with a user who has access to more than one organization/cost center, select the new organization and cost center on the top menu and click in Configure Current Organization button.

Events should appear in analytics redshift in a hour or so, into "vtex"."schemaless"."b2b_suite_buyerorg_data_raw" schema

[Workspace](https://takeda--b2bstore005.myvtex.com/)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-organizations/assets/1576737/4bc2af70-6512-4328-aad2-d135b4da6747)

Types:

```
type ChangeTeamFieldsMetric = {
  date: string
  user_id: string
  user_role: string
  user_email: string
  org_id: string
  cost_center_id: string
}

type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }

export type ChangeTeamMetric = {
  kind: 'change-team-ui-event'
  description: 'User change team/organization - UI'
}

export type Metric = {
  name: 'b2b-suite-buyerorg-data'
  account: string
} & (ImpersonateMetric | StopImpersonateMetric | ChangeTeamMetric)

```

Example of query and results:

```
SELECT
    payload.account,
    payload.kind,
    payload.fields.date,
    payload.fields.user_id,
    payload.fields.user_role,
    payload.fields.user_email,
    payload.fields.org_id,
    payload.fields.cost_center_id

FROM "vtex"."schemaless"."b2b_suite_buyerorg_data_raw"
WHERE payload.name = 'b2b-suite-buyerorg-data'
and payload.kind in ('change-team-ui-event')
order by ingestion_time desc
```

![image](https://github.com/vtex-apps/b2b-organizations/assets/1576737/e48475d4-9c21-425d-b732-a9459326b09d)


#### How does this PR make you feel?
![](https://media.giphy.com/media/M90mJvfWfd5mbUuULX/giphy.gif)
