### PR TITLE
add condition for "manage-organization" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
+
+### Fix
+
+- Add condition to use the `manage-organization` permission
 
 ## [1.25.0] - 2023-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fix
+
+### Added
 
 - Add condition to use the `manage-organization` permission
 

--- a/react/components/EditUserModal.tsx
+++ b/react/components/EditUserModal.tsx
@@ -23,6 +23,7 @@ interface Props {
   canEdit?: boolean
   canEditSales?: boolean
   isSalesAdmin: boolean
+  canManageOrg?: boolean
 }
 
 interface DropdownOption {
@@ -42,6 +43,7 @@ const EditUserModal: FunctionComponent<Props> = ({
   canEdit,
   canEditSales,
   isSalesAdmin,
+  canManageOrg
 }) => {
   const { formatMessage } = useIntl()
   const [userState, setUserState] = useState({} as UserDetails)
@@ -113,6 +115,10 @@ const EditUserModal: FunctionComponent<Props> = ({
 
     const filteredArray = rolesData.listRoles.filter((role: any) => {
       if (isAdmin) return true
+
+      if(canManageOrg) {
+        return true
+      }
 
       if (role.slug.includes('customer') && canEdit) {
         return true

--- a/react/components/NewUserModal.tsx
+++ b/react/components/NewUserModal.tsx
@@ -22,6 +22,7 @@ interface Props {
   canEdit?: boolean
   canEditSales?: boolean
   isSalesAdmin?: boolean
+  canManageOrg: boolean
 }
 
 interface DropdownOption {
@@ -39,6 +40,7 @@ const NewUserModal: FunctionComponent<Props> = ({
   canEdit,
   canEditSales,
   isSalesAdmin,
+  canManageOrg
 }) => {
   const { formatMessage } = useIntl()
   const [userState, setUserState] = useState({
@@ -116,6 +118,8 @@ const NewUserModal: FunctionComponent<Props> = ({
 
     const filteredArray = rolesData.listRoles.filter((role: any) => {
       if (isAdmin) return true
+
+      if(canManageOrg) return true
 
       if (role.slug.includes('customer') && canEdit) {
         return true

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -108,7 +108,10 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     }
   }
 
+  const canManageOrganization = permissions.includes('manage-organization')
+
   const canEdit = isAdmin || permissions.includes('add-users-organization')
+
   const canEditSales =
     isAdmin ||
     permissions.includes('add-sales-users-all') ||
@@ -387,14 +390,19 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
   }
 
   const getSchema = () => {
-    const isEnabled = ({ role: { slug } }: { role: { slug: string } }) =>
-      ruleClickEnabled({
-        isAdmin,
-        canEditSales,
-        slug,
-        canEdit,
-        isSalesAdmin,
-      })
+    const isEnabled = ({ role: { slug } }: { role: { slug: string } }) => {
+      if (!canManageOrganization) {
+        return ruleClickEnabled({
+          isAdmin,
+          canEditSales,
+          slug,
+          canEdit,
+          isSalesAdmin,
+        })
+      }
+
+      return canManageOrganization
+    }
 
     const properties = {
       email: {
@@ -535,7 +543,20 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
   }
 
   const handleRowClick = ({ rowData }: CellRendererProps) => {
-    if (
+    if (canManageOrganization) {
+      setEditUserDetails({
+        id: rowData.id,
+        roleId: rowData.roleId,
+        userId: rowData.userId,
+        clId: rowData.clId,
+        orgId: rowData.orgId,
+        costId: rowData.costId,
+        name: rowData.name,
+        email: rowData.email,
+        canImpersonate: rowData.canImpersonate,
+      })
+      setEditUserModalOpen(true)
+    } else if (
       !ruleClickEnabled({
         isAdmin,
         canEditSales,
@@ -544,21 +565,9 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
         isSalesAdmin,
       })
     ) {
+      // eslint-disable-next-line no-useless-return
       return
     }
-
-    setEditUserDetails({
-      id: rowData.id,
-      roleId: rowData.roleId,
-      userId: rowData.userId,
-      clId: rowData.clId,
-      orgId: rowData.orgId,
-      costId: rowData.costId,
-      name: rowData.name,
-      email: rowData.email,
-      canImpersonate: rowData.canImpersonate,
-    })
-    setEditUserModalOpen(true)
   }
 
   const handleSort = ({

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -667,6 +667,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
           canEdit={canEdit}
           canEditSales={canEditSales}
           isSalesAdmin={isSalesAdmin}
+          canManageOrg={canManageOrganization}
         />
       )}
       {editUserModalOpen && (
@@ -682,6 +683,7 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
           canEdit={canEdit}
           canEditSales={canEditSales}
           isSalesAdmin={isSalesAdmin}
+          canManageOrg={canManageOrganization}
         />
       )}
       <RemoveUserModal


### PR DESCRIPTION
#### What problem is this solving?

In our production case, we need to have the role/permission to be able to edit, delete, and add new users in any category (sales or Customers). 

We achieved the desired behavior by adding a handler for `manage-organization` permission. 

If the user has the role with `manage-organization` permission he should be able to:
- add, edit, or delete a user from any category;
- can set any role (not only by his category);

#### How to test it?

[Workspace](https://ilyapoc--helmethouseprod.myvtex.com)

