### PR TITLE
fix: remove the role slug check and use permission to impersonate user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix to impersonate user with the role `sales`
+
 ## [1.27.1] - 2023-08-17
 
 ### Fix 

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -123,9 +123,10 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     'impersonate-users-organization'
   )
 
-  const canImpersonateCost = permissions.includes(
+  const canImpersonateCost = (rowData: B2BUserSimple) => permissions.includes(
     'impersonate-users-costcenter'
-  )
+  ) &&
+    rowData.costId === costCenterData?.getCostCenterByIdStorefront?.id
 
   const { data, loading, refetch } = useQuery(GET_USERS, {
     variables: {
@@ -329,32 +330,9 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
 
   const handleImpersonation = (rowData: B2BUserSimple) => {
     if (
-      (!canImpersonateAll && !canImpersonateOrg && !canImpersonateCost) ||
-      rowData.role.slug.includes('sales')
+      !canImpersonateAll && !canImpersonateOrg && !canImpersonateCost(rowData)
     ) {
       showToast(formatMessage(storeMessages.toastImpersonateForbidden))
-
-      return
-    }
-
-    if (
-      !canImpersonateAll &&
-      canImpersonateOrg &&
-      !rowData.role.slug.includes('customer')
-    ) {
-      showToast(formatMessage(storeMessages.toastImpersonateForbidden))
-
-      return
-    }
-
-    if (
-      !canImpersonateAll &&
-      !canImpersonateOrg &&
-      canImpersonateCost &&
-      rowData.costId !== costCenterData?.getCostCenterByIdStorefront?.id
-    ) {
-      showToast(formatMessage(storeMessages.toastImpersonateForbidden))
-
       return
     }
 

--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -123,11 +123,6 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     'impersonate-users-organization'
   )
 
-  const canImpersonateCost = (rowData: B2BUserSimple) => permissions.includes(
-    'impersonate-users-costcenter'
-  ) &&
-    rowData.costId === costCenterData?.getCostCenterByIdStorefront?.id
-
   const { data, loading, refetch } = useQuery(GET_USERS, {
     variables: {
       ...initialState,
@@ -145,6 +140,10 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
     ssr: false,
     skip: isAdmin,
   })
+
+  const canImpersonateCost = (rowData: B2BUserSimple) =>
+    permissions.includes('impersonate-users-costcenter') &&
+    rowData.costId === costCenterData?.getCostCenterByIdStorefront?.id
 
   const [addUser] = useMutation(ADD_USER)
   const [updateUser] = useMutation(UPDATE_USER)
@@ -330,9 +329,12 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
 
   const handleImpersonation = (rowData: B2BUserSimple) => {
     if (
-      !canImpersonateAll && !canImpersonateOrg && !canImpersonateCost(rowData)
+      !canImpersonateAll &&
+      !canImpersonateOrg &&
+      !canImpersonateCost(rowData)
     ) {
       showToast(formatMessage(storeMessages.toastImpersonateForbidden))
+
       return
     }
 


### PR DESCRIPTION
#### What problem is this solving?

The users with the `sales` roles can't impersonate users, even if they have permission.

#### How to test it?

- Open the path /account#/organization, log with sales role account
- Go to Users
- Click in the 3 points to impersonate the user.

[Workspace](https://www.rivieraworks.ro/account?workspace=ki910328#/organization)

#### Screenshots or example usage:

![Screen Recording 2023-10-05 at 17 27 10](https://github.com/vtex-apps/b2b-organizations/assets/5332361/b28caa9d-957d-4d82-900c-82b0c2823281)
