### PR TITLE
Feat: Add removed alerts in localstorage

### DIFF
--- a/react/components/BulkImportList/BulkImportList.tsx
+++ b/react/components/BulkImportList/BulkImportList.tsx
@@ -14,7 +14,7 @@ const BulkImportList = () => {
       </ImportAlertError>
     )
 
-  if (data) return <ImportAlertList data={data} onDismiss={() => {}} />
+  if (data) return <ImportAlertList data={data} />
 
   return <></>
 }

--- a/react/components/ImportAlertList/ImportAlertList.tsx
+++ b/react/components/ImportAlertList/ImportAlertList.tsx
@@ -4,6 +4,7 @@ import type { ImportStatus } from '@vtex/bulk-import-ui'
 import { ImportAlert } from '@vtex/bulk-import-ui'
 
 import ImportReportModal from '../ImportReportModal/ImportReportModal'
+import useClosedAlerts from '../../hooks/useClosedAlerts'
 
 type ImportAlertData = ImportStatus & {
   importId: string
@@ -12,17 +13,23 @@ type ImportAlertData = ImportStatus & {
 interface ImportAlertListProps {
   /** A list of object with data about the status of this import. */
   data: ImportAlertData[]
-  onDismiss?: (importStatus: ImportStatus) => void
 }
 
-const ImportAlertList = ({ data, onDismiss }: ImportAlertListProps) => {
+const ImportAlertList = ({ data }: ImportAlertListProps) => {
+  const { getClosedAlerts, addClosedAlert } = useClosedAlerts()
+
+  const filteredAlert = data.filter(
+    itemData =>
+      !getClosedAlerts().find(alertId => alertId === itemData.importId)
+  )
+
   return (
     <Stack>
-      {data.map(itemData => (
+      {filteredAlert.map(itemData => (
         <ImportAlert
           key={itemData.importId}
           data={itemData}
-          onDismiss={onDismiss ? () => onDismiss?.(itemData) : undefined}
+          onDismiss={() => addClosedAlert(itemData.importId)}
           detailsModal={(open, setOpen) => (
             <ImportReportModal
               onOpenChange={setOpen}

--- a/react/components/ImportAlertList/ImportAlertList.tsx
+++ b/react/components/ImportAlertList/ImportAlertList.tsx
@@ -16,11 +16,10 @@ interface ImportAlertListProps {
 }
 
 const ImportAlertList = ({ data }: ImportAlertListProps) => {
-  const { getClosedAlerts, addClosedAlert } = useClosedAlerts()
+  const { closedAlerts, addClosedAlert } = useClosedAlerts()
 
   const filteredAlert = data.filter(
-    itemData =>
-      !getClosedAlerts().find(alertId => alertId === itemData.importId)
+    itemData => !closedAlerts.find(alertId => alertId === itemData.importId)
   )
 
   return (

--- a/react/hooks/useClosedAlerts.ts
+++ b/react/hooks/useClosedAlerts.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+
+import useLocalStorage from './useLocalStorage'
+
+const useClosedAlerts = () => {
+  const [getClosedAlerts, setClosedAlerts] = useLocalStorage(
+    'closed-alerts-x',
+    [] as string[]
+  )
+
+  const addClosedAlert = useCallback((importId: string) => {
+    if (getClosedAlerts().find(alertId => alertId === importId)) {
+      return
+    }
+
+    setClosedAlerts([...getClosedAlerts(), importId])
+  }, [])
+
+  const removeClosedAlert = useCallback((importId: string) => {
+    const filteredAlerts = getClosedAlerts().filter(
+      alertId => alertId !== importId
+    )
+
+    setClosedAlerts(filteredAlerts)
+  }, [])
+
+  return { getClosedAlerts, addClosedAlert, removeClosedAlert }
+}
+
+export default useClosedAlerts

--- a/react/hooks/useClosedAlerts.ts
+++ b/react/hooks/useClosedAlerts.ts
@@ -1,30 +1,26 @@
-import { useCallback } from 'react'
-
 import useLocalStorage from './useLocalStorage'
 
 const useClosedAlerts = () => {
-  const [getClosedAlerts, setClosedAlerts] = useLocalStorage(
-    'closed-alerts-x',
+  const [closedAlerts, setClosedAlerts] = useLocalStorage(
+    'bulk-import-closed-alerts',
     [] as string[]
   )
 
-  const addClosedAlert = useCallback((importId: string) => {
-    if (getClosedAlerts().find(alertId => alertId === importId)) {
+  const addClosedAlert = (importId: string) => {
+    if (closedAlerts.find(alertId => alertId === importId)) {
       return
     }
 
-    setClosedAlerts([...getClosedAlerts(), importId])
-  }, [])
+    setClosedAlerts([...closedAlerts, importId])
+  }
 
-  const removeClosedAlert = useCallback((importId: string) => {
-    const filteredAlerts = getClosedAlerts().filter(
-      alertId => alertId !== importId
-    )
+  const removeClosedAlert = (importId: string) => {
+    const filteredAlerts = closedAlerts.filter(alertId => alertId !== importId)
 
     setClosedAlerts(filteredAlerts)
-  }, [])
+  }
 
-  return { getClosedAlerts, addClosedAlert, removeClosedAlert }
+  return { closedAlerts, addClosedAlert, removeClosedAlert }
 }
 
 export default useClosedAlerts

--- a/react/hooks/useLocalStorage.ts
+++ b/react/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+const useLocalStorage = <T>(key: string, initialValue: T) => {
+  const storedValue = localStorage.getItem(key)
+
+  const [value, setValue] = useState(
+    (storedValue ? JSON.parse(storedValue) : initialValue) as T
+  )
+
+  const setStoredValue = (newValue: T) => {
+    setValue(newValue)
+    localStorage.setItem(key, JSON.stringify(newValue))
+  }
+
+  const getStoreValue = () => {
+    return (storedValue ? JSON.parse(storedValue) : initialValue) as T
+  }
+
+  return [getStoreValue, setStoredValue] as const
+}
+
+export default useLocalStorage

--- a/react/hooks/useLocalStorage.ts
+++ b/react/hooks/useLocalStorage.ts
@@ -12,11 +12,7 @@ const useLocalStorage = <T>(key: string, initialValue: T) => {
     localStorage.setItem(key, JSON.stringify(newValue))
   }
 
-  const getStoreValue = () => {
-    return (storedValue ? JSON.parse(storedValue) : initialValue) as T
-  }
-
-  return [getStoreValue, setStoredValue] as const
+  return [value, setStoredValue] as const
 }
 
 export default useLocalStorage


### PR DESCRIPTION
#### What problem is this solving?


This pull request introduces a new feature that enables the removal of ImportAlerts upon clicking the dismiss button. The information about which ImportAlerts should be hidded is now registered in the LocalStorage.

#### How to test it?

[Workspace](https://removealert--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations#/organizations)

#### Screenshots or example usage:

https://github.com/vtex-apps/b2b-organizations/assets/51174217/7b24e1ff-0bee-454f-ba38-ac6a13e66f56


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![Running](https://media.giphy.com/media/QKUTD5lAgpgrSHpbMB/giphy.gif)
