### PR TITLE
Fix the fetch data retry on Bulk Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix unauthorized requests breaking on bulk import
+
 ## [1.29.1] - 2024-01-04
 
 ### Fixed

--- a/react/components/BulkImportList/BulkImportList.tsx
+++ b/react/components/BulkImportList/BulkImportList.tsx
@@ -1,27 +1,22 @@
-import React from 'react'
-import { ImportAlertError } from '@vtex/bulk-import-ui'
+import React, { useState } from 'react'
 
-import { useBulkImportsQuery, useTranslate } from '../../hooks'
+import { useBulkImportsQuery } from '../../hooks'
 import ImportAlertList from '../ImportAlertList/ImportAlertList'
 
 const BulkImportList = () => {
-  const { data, error, mutate } = useBulkImportsQuery()
-
-  const { translate: t } = useTranslate()
+  const [shouldPoll, setShouldPoll] = useState(true)
+  const { data, error } = useBulkImportsQuery({
+    shouldPoll,
+    onError: () => setShouldPoll(false),
+  })
 
   if (error?.message) {
     console.error(error)
-
-    return (
-      <ImportAlertError onTryAgainClick={mutate}>
-        {t('errorMessage')}
-      </ImportAlertError>
-    )
   }
 
   if (data) return <ImportAlertList data={data} />
 
-  return <></>
+  return null
 }
 
 export default BulkImportList

--- a/react/components/BulkImportList/BulkImportList.tsx
+++ b/react/components/BulkImportList/BulkImportList.tsx
@@ -1,13 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { useBulkImportsQuery } from '../../hooks'
 import ImportAlertList from '../ImportAlertList/ImportAlertList'
 
 const BulkImportList = () => {
-  const [shouldPoll, setShouldPoll] = useState(true)
   const { data, error } = useBulkImportsQuery({
-    shouldPoll,
-    onError: () => setShouldPoll(false),
+    shouldPoll: true,
   })
 
   if (error?.message) {

--- a/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
+++ b/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
@@ -12,7 +12,7 @@ import { useSWRConfig } from 'swr'
 
 import CreateOrganizationModal from '../CreateOrganizationModal'
 import { organizationMessages as messages } from '../../admin/utils/messages'
-import { useTranslate } from '../../hooks'
+import { useBulkImportsQuery, useTranslate } from '../../hooks'
 import ReportErrorScreen from '../UploadModal/ReportErrorScreen'
 import ReportScreen from '../UploadModal/ReportScreen'
 import ReportSuccessScreen from '../UploadModal/ReportSuccessScreen'
@@ -33,6 +33,7 @@ const CreateOrganizationButton = () => {
   const [uploadModalOpen, setUploadModalOpen] = useState(false)
   const { mutate } = useSWRConfig()
   const { startBulkImport } = useStartBulkImport()
+  const { data } = useBulkImportsQuery()
 
   const handleUploadFinish = async (result: UploadFileData) => {
     if (result.status === 'success' && result.data?.fileData?.importId) {
@@ -55,11 +56,13 @@ const CreateOrganizationButton = () => {
           icon={<IconPencil />}
           onClick={() => setOpen(true)}
         />
-        <MenuItem
-          label={formatMessage(messages.addBulk)}
-          icon={<IconCloudArrowUp />}
-          onClick={() => setUploadModalOpen(true)}
-        />
+        {!!data && (
+          <MenuItem
+            label={formatMessage(messages.addBulk)}
+            icon={<IconCloudArrowUp />}
+            onClick={() => setUploadModalOpen(true)}
+          />
+        )}
       </Menu>
       <CreateOrganizationModal open={open} onOpenChange={setOpen} />
       <UploadModal

--- a/react/hooks/useBulkImportsQuery.ts
+++ b/react/hooks/useBulkImportsQuery.ts
@@ -4,7 +4,14 @@ import type { Session } from '../modules/session'
 import { useSessionResponse } from '../modules/session'
 import { getBulkImportList } from '../services'
 
-const useBulkImportQuery = () => {
+type UseBulkImportQueryProps = {
+  shouldPoll?: boolean
+  onError?: () => void
+}
+
+const useBulkImportQuery = (
+  { shouldPoll, onError }: UseBulkImportQueryProps = { shouldPoll: false }
+) => {
   const session = useSessionResponse() as Session
 
   const account = session?.namespaces?.account?.accountName?.value
@@ -13,7 +20,8 @@ const useBulkImportQuery = () => {
     account ? '/buyer-orgs' : null,
     () => getBulkImportList(account),
     {
-      refreshInterval: 30 * 1000, // 30 seconds
+      refreshInterval: shouldPoll ? 30 * 1000 : 0, // 30 seconds
+      onError,
     }
   )
 }

--- a/react/hooks/useBulkImportsQuery.ts
+++ b/react/hooks/useBulkImportsQuery.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr'
+import { useState } from 'react'
 
 import type { Session } from '../modules/session'
 import { useSessionResponse } from '../modules/session'
@@ -6,13 +7,16 @@ import { getBulkImportList } from '../services'
 
 type UseBulkImportQueryProps = {
   shouldPoll?: boolean
-  onError?: () => void
 }
 
 const useBulkImportQuery = (
-  { shouldPoll, onError }: UseBulkImportQueryProps = { shouldPoll: false }
+  { shouldPoll: initialShouldPoll }: UseBulkImportQueryProps = {
+    shouldPoll: false,
+  }
 ) => {
   const session = useSessionResponse() as Session
+
+  const [shouldPoll, setShouldPoll] = useState(initialShouldPoll)
 
   const account = session?.namespaces?.account?.accountName?.value
 
@@ -20,8 +24,14 @@ const useBulkImportQuery = (
     account ? '/buyer-orgs' : null,
     () => getBulkImportList(account),
     {
-      refreshInterval: shouldPoll ? 30 * 1000 : 0, // 30 seconds
-      onError,
+      refreshInterval: shouldPoll ? 5 * 1000 : 0, // 30 seconds
+      onError: errorData => {
+        const status = errorData?.response?.status ?? 0
+
+        if (status >= 400 && status < 500) {
+          setShouldPoll(false)
+        }
+      },
     }
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently, when an unauthorized user attempts to access the bulk import feature, an error is displayed. This PR addresses this issue by verifying the user's authorization to use the bulk import functionality. If authorized, the components from the feature are rendered. Additionally, a request is made to check for authorization, and upon successful validation, the "Import in bulk" option is displayed along with the Last Bulk Import Item.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://testpermissions--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations#/organizations)

#### Screenshots or example usage:

![Screenshot 2024-01-10 at 16 16 54](https://github.com/vtex-apps/b2b-organizations/assets/51174217/0de204db-f19e-4fb6-b456-b843a5ea06aa)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![Fixing](https://media.giphy.com/media/zxcVtaJRjpL4Pkrp8q/giphy.gif)

[B2BTEAM-1540](https://vtex-dev.atlassian.net/browse/B2BTEAM-1540)

[B2BTEAM-1540]: https://vtex-dev.atlassian.net/browse/B2BTEAM-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ