### PR TITLE
feat: add help footer on bulk import upload modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add help footer on bulk import upload modal
+
 ## [1.30.2] - 2024-01-31
 
 ### Added

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "سحب وإسقاط الملف",
   "admin/b2b-organizations.bulk-import.upload.filesType": "نوع الملف",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "الحجم الأقصي",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "غير معروف",
   "admin/b2b-organizations.bulk-import.upload.upload": "رفع",
   "admin/b2b-organizations.bulk-import.upload.uploading": "تحميل الملف والتحقق من صحته...",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Плъзнете и пуснете файл",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Вид файл",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Максимален размер",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Неизвестно",
   "admin/b2b-organizations.bulk-import.upload.upload": "Качване",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Качване и валидиране на файл...",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Arrossega i deixa anar el fitxer",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tipus de fitxer",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Mida màxima",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Desconegut",
   "admin/b2b-organizations.bulk-import.upload.upload": "Penja",
   "admin/b2b-organizations.bulk-import.upload.uploading": "S'està penjant i validant el fitxer...",

--- a/messages/context.json
+++ b/messages/context.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Title of the drag and drop area",
   "admin/b2b-organizations.bulk-import.upload.filesType": "The supported file types",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "The supported max size",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "An unknown row name within the error report",
   "admin/b2b-organizations.bulk-import.upload.upload": "The button for uploading a file",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Text indicating that a file is being uploaded",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Vyberte soubor přetažením",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Typ souboru",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maximální velikost",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Neznámé",
   "admin/b2b-organizations.bulk-import.upload.upload": "Nahrát",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Nahrávání a ověřování souboru...",

--- a/messages/da.json
+++ b/messages/da.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Træk og slip fil",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Filtype",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maks. størrelse",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Ukendt",
   "admin/b2b-organizations.bulk-import.upload.upload": "Upload",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Uploader og validerer fil...",

--- a/messages/de.json
+++ b/messages/de.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Datei ziehen und ablegen",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Dateityp",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maximale Größe",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Unbekannt",
   "admin/b2b-organizations.bulk-import.upload.upload": "Hochladen",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Hochladen und Validierung der Datei...",

--- a/messages/el.json
+++ b/messages/el.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Σύρετε και αφήστε αρχείο",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Τύπος αρχείου",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Μέγιστο μέγεθος",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Άγνωστος",
   "admin/b2b-organizations.bulk-import.upload.upload": "Φόρτωση",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Φόρτωση και επικύρωση αρχείου...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Drag and drop file",
   "admin/b2b-organizations.bulk-import.upload.filesType": "File type",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Max size",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Unknown",
   "admin/b2b-organizations.bulk-import.upload.upload": "Upload",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Uploading and validating file...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Arrastrar y soltar archivo",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tipo de archivo",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Tamaño máximo",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Desconocido",
   "admin/b2b-organizations.bulk-import.upload.upload": "Cargar",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Cargando y validando archivo...",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Vedä ja pudota tiedosto",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tiedostotyyppi",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maksimikoko",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Tuntematon",
   "admin/b2b-organizations.bulk-import.upload.upload": "Lähetä",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Lähetetään ja vahvistetaan tiedostoa...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Glisser et déposer le fichier",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Type de fichier",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Taille maximale",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Inconnu",
   "admin/b2b-organizations.bulk-import.upload.upload": "Télécharger",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Téléchargement et validation du fichier...",

--- a/messages/id.json
+++ b/messages/id.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Seret dan jatuhkan file",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Jenis file",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Ukuran maks",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Tidak diketahui",
   "admin/b2b-organizations.bulk-import.upload.upload": "Unggah",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Mengunggah dan memvalidasi file...",

--- a/messages/it.json
+++ b/messages/it.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Trascina e rilascia file",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tipo di file",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Dimensione massima",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Sconosciuto",
   "admin/b2b-organizations.bulk-import.upload.upload": "Carica",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Caricamento e convalida file in corso...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "ファイルをドラッグ＆ドロップ",
   "admin/b2b-organizations.bulk-import.upload.filesType": "ファイル形式",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "最大サイズ",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "不明",
   "admin/b2b-organizations.bulk-import.upload.upload": "アップロードする",
   "admin/b2b-organizations.bulk-import.upload.uploading": "ファイルのアップロードと検証中です",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "파일 끌어서 놓기",
   "admin/b2b-organizations.bulk-import.upload.filesType": "파일 유형",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "최대 크기",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "알 수 없음",
   "admin/b2b-organizations.bulk-import.upload.upload": "업로드",
   "admin/b2b-organizations.bulk-import.upload.uploading": "파일 업로드 및 유효성 검사...",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Bestand slepen en neerzetten",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Bestandstype",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maximale grootte",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Onbekend",
   "admin/b2b-organizations.bulk-import.upload.upload": "Upload",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Bestand uploaden en valideren...",

--- a/messages/no.json
+++ b/messages/no.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Dra-og-slipp-fil",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Filtype",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maks størrelse",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Ukjent",
   "admin/b2b-organizations.bulk-import.upload.upload": "Last opp",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Laster opp og godkjenner fil...",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Przeciągnij i upuść plik",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Rodzaj pliku",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Rozmiar maksymalny",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Nieznany",
   "admin/b2b-organizations.bulk-import.upload.upload": "Prześlij",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Przesyłanie i sprawdzanie pliku...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Arraste e solte o arquivo",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tipo de arquivo",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Tamanho máximo",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Desconhecido",
   "admin/b2b-organizations.bulk-import.upload.upload": "Enviar",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Enviando e validando o arquivo...",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Încarcă fișierul cu ajutorul funcției de drag and drop",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Tip fișier",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Dimensiune maximă",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Necunoscut",
   "admin/b2b-organizations.bulk-import.upload.upload": "Încarcă",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Se încarcă și se validează fișierul...",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Перетяните файл сюда",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Тип файла",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Максимальный размер",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Неизвестно",
   "admin/b2b-organizations.bulk-import.upload.upload": "Загрузить",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Загрузка и проверка файла...",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Presuňte súbory potiahnutím",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Typ súboru",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Maximálna veľkosť",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Neznáme",
   "admin/b2b-organizations.bulk-import.upload.upload": "Nahrať",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Nahrávanie a overovanie súborov...",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Povlecite in spustite datoteko",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Vrsta datoteke",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Največja velikost",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Neznano",
   "admin/b2b-organizations.bulk-import.upload.upload": "Naloži",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Nalaganje in preverjanje datoteke...",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Drag 'n Drop fil",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Filtyp",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Max storlek",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Unknown",
   "admin/b2b-organizations.bulk-import.upload.upload": "Ladda Upp",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Laddar upp och validerar fil...",

--- a/messages/th.json
+++ b/messages/th.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "ลากและวางไฟล์",
   "admin/b2b-organizations.bulk-import.upload.filesType": "ชนิดไฟล์",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "ขนาดสูงสุด",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "ไม่ทราบ",
   "admin/b2b-organizations.bulk-import.upload.upload": "อัปโหลด",
   "admin/b2b-organizations.bulk-import.upload.uploading": "กำลังอัปโหลดและตรวจสอบความถูกต้องของไฟล์...",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -102,6 +102,7 @@
   "admin/b2b-organizations.bulk-import.upload.dragDrop": "Перетягніть файл сюди",
   "admin/b2b-organizations.bulk-import.upload.filesType": "Тип файлу",
   "admin/b2b-organizations.bulk-import.upload.maxSize": "Максимальний розмір",
+  "admin/b2b-organizations.bulk-import.upload.helpLinks": "Need help? Download the <template-link>VTEX file template</template-link> or view our <best-practices-link>best practices guide</best-practices-link>.",
   "admin/b2b-organizations.bulk-import.upload.unknownRowName": "Невідомо",
   "admin/b2b-organizations.bulk-import.upload.upload": "Завантажити",
   "admin/b2b-organizations.bulk-import.upload.uploading": "Завантаження та перевірка файлу...",

--- a/react/bulkImport/messages.ts
+++ b/react/bulkImport/messages.ts
@@ -26,6 +26,7 @@ export type BulkImportMessageKey =
   | 'reportInformationStep3Upload'
   | 'reportInformationStep3Import'
   | 'reportInformationStep4'
+  | 'helpLinks'
   | 'downloadReviewedLink'
   | 'errorMessage'
   | 'permissionAlertTooltip'
@@ -48,6 +49,9 @@ export const bulkUploadMessages: Record<
   },
   maxSize: {
     id: 'admin/b2b-organizations.bulk-import.upload.maxSize',
+  },
+  helpLinks: {
+    id: 'admin/b2b-organizations.bulk-import.upload.helpLinks',
   },
   unknownRowName: {
     id: 'admin/b2b-organizations.bulk-import.upload.unknownRowName',

--- a/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
+++ b/react/components/CreateOrganizationButton/CreateOrganizationButton.tsx
@@ -5,6 +5,7 @@ import {
   Menu,
   MenuItem,
   PageHeaderMenuButton,
+  Text,
   useMenuState,
 } from '@vtex/admin-ui'
 import { UploadModal } from '@vtex/bulk-import-ui'
@@ -27,9 +28,13 @@ import useStartBulkImport from '../../hooks/useStartBulkImport'
 import ReportDownloadLink from '../ReportDownloadLink/ReportDownloadLink'
 import { ValidationScreen } from '../UploadingScreen'
 import { ImportInBulkTooltip } from '../ImportInBulkTooltip'
+import {
+  B2B_BULK_IMPORT_TEMPLATE_LINK,
+  B2B_BULK_IMPORT_BEST_PRACTICES_LINK,
+} from '../../utils/constants'
 
 const CreateOrganizationButton = () => {
-  const { formatMessage } = useTranslate()
+  const { formatMessage, translate: t } = useTranslate()
   const menuState = useMenuState()
   const [open, setOpen] = useState(false)
   const [uploadModalOpen, setUploadModalOpen] = useState(false)
@@ -70,6 +75,18 @@ const CreateOrganizationButton = () => {
       </Menu>
       <CreateOrganizationModal open={open} onOpenChange={setOpen} />
       <UploadModal
+        helpContent={
+          <Text variant="body">
+            {t('helpLinks', {
+              'template-link': (content: string) => (
+                <a href={B2B_BULK_IMPORT_TEMPLATE_LINK}>{content}</a>
+              ),
+              'best-practices-link': (content: string) => (
+                <a href={B2B_BULK_IMPORT_BEST_PRACTICES_LINK}>{content}</a>
+              ),
+            })}
+          </Text>
+        }
         open={uploadModalOpen}
         onOpenChange={setUploadModalOpen}
         uploadFile={uploadBulkImportFile}

--- a/react/utils/constants.ts
+++ b/react/utils/constants.ts
@@ -1,1 +1,4 @@
 export const B2B_CHECKOUT_SESSION_KEY = 'b2b-checkout-settings'
+export const B2B_BULK_IMPORT_TEMPLATE_LINK =
+  'https://io.vtex.com.br/b2b-bulk-import/b2b-bulk-import-template.xlsx'
+export const B2B_BULK_IMPORT_BEST_PRACTICES_LINK = 'https://help.vtex.com/'


### PR DESCRIPTION
#### What problem is this solving?

Add missing help footer on the bulk import upload modal.
Before:
![Captura de Tela 2024-02-26 às 10 25 53](https://github.com/vtex-apps/b2b-organizations/assets/131273915/bb81e3b9-bd6a-4da5-b38a-b039e8b8acbe)

After:
![Captura de Tela 2024-02-26 às 10 18 06](https://github.com/vtex-apps/b2b-organizations/assets/131273915/90700406-61b2-41c7-b675-46d53bfb3ec0)

#### How to test it?
Go to Organizations app, click on "New > Bulk Import". You should see the upload modal and it should have a footer with links to the template file and help center.
[Workspace](https://b2bteam1564--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations)
