### PR TITLE
Added Trade Name to the Organization listing page

### DIFF
--- a/react/admin/OrganizationRequestsTable.tsx
+++ b/react/admin/OrganizationRequestsTable.tsx
@@ -61,6 +61,9 @@ const OrganizationRequestsTable: FunctionComponent = () => {
       name: {
         title: formatMessage(messages.columnName),
       },
+      tradeName: {
+        title: formatMessage(messages.columnTradeName),
+      },
       b2bCustomerAdmin: {
         title: formatMessage(messages.columnAdmin),
         cellRenderer: ({

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -219,6 +219,9 @@ export const organizationMessages = defineMessages({
   tableColumnName: {
     id: `${adminPrefix}organizations-admin.table.column-name.title`,
   },
+  tableColumnTradeName: {
+    id: `${adminPrefix}organizations-admin.table.column-tradeName.title`,
+  },
   columnStatus: {
     id: `${adminPrefix}organizations-admin.table.column-status.title`,
   },
@@ -350,6 +353,9 @@ export const organizationRequestMessages = defineMessages({
   },
   columnName: {
     id: `${adminPrefix}organization-requests-admin.table.column-name.title`,
+  },
+  columnTradeName: {
+    id: `${adminPrefix}organization-requests-admin.table.column-tradeName.title`,
   },
   columnAdmin: {
     id: `${adminPrefix}organization-requests-admin.table.column-admin.title`,

--- a/react/graphql/getOrganizationRequests.graphql
+++ b/react/graphql/getOrganizationRequests.graphql
@@ -20,6 +20,7 @@ query GetOrganizationRequests(
     data {
       id
       name
+      tradeName
       b2bCustomerAdmin {
         email
       }

--- a/react/graphql/getOrganizations.graphql
+++ b/react/graphql/getOrganizations.graphql
@@ -20,6 +20,7 @@ query GetOrganizations(
     data {
       id
       name
+      tradeName
       status
     }
   }

--- a/react/organizations/table.tsx
+++ b/react/organizations/table.tsx
@@ -9,6 +9,7 @@ import { useNavigateToDetailsPage } from './navigate'
 interface OrganizationSimple {
   id: string
   name: string
+  tradeName: string
   status: string
 }
 
@@ -31,6 +32,20 @@ export const useOrgsTableColumns = () => {
         type: 'text',
         columnType: 'name',
         mapText: ({ name }) => name,
+        render: ({ data }) => (
+          <div className={csx({ minWidth: '10rem' })}>{data}</div>
+        ),
+      },
+      sortable: true,
+    },
+    {
+      id: 'tradeName',
+      header: formatMessage(messages.tableColumnTradeName),
+      width: '3fr',
+      resolver: {
+        type: 'text',
+        columnType: 'name',
+        mapText: ({ tradeName }) => tradeName,
         render: ({ data }) => (
           <div className={csx({ minWidth: '10rem' })}>{data}</div>
         ),

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
+    "jsx": "react",
     "noEmitOnError": false,
     "lib": ["dom"],
     "module": "esnext",


### PR DESCRIPTION
#### What problem is this solving?
SBD utilizes the trade name for the name of the company and the name as their internal ID. This change allows you to search by both fields.
Also implements an auto-update 
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://wender--sbdstoruat.myvtex.com/admin/b2b-organizations/organizations/#/organizations)

#### Screenshots or example usage:
<img width="1773" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/24723/289fc913-7cdc-4665-85a2-c50fac2a1da2">

