### PR TITLE
Fix/save edit address data admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Save add, edit and delete address within the Cost Center in admin
+
+### Fixed
+
 - Pagination bug on admin organization details collections assignment UI
 
 ### Added

--- a/react/admin/CostCenterDetails.tsx
+++ b/react/admin/CostCenterDetails.tsx
@@ -305,6 +305,8 @@ const CostCenterDetails: FunctionComponent = () => {
       (item: any) => item.addressId === uid
     )
 
+    setLoadingState(true)
+
     let isDuplicatedError = false
 
     if (duplicated !== undefined) {
@@ -333,6 +335,40 @@ const CostCenterDetails: FunctionComponent = () => {
 
       const newAddresses = [...addresses, newAddress]
 
+      const variables = {
+        id: params.id,
+        input: {
+          addresses: newAddresses
+            .sort(item => (item.checked ? -1 : 1))
+            .map(item => {
+              return {
+                ...item,
+                checked: undefined,
+              }
+            }),
+        },
+      }
+
+      updateCostCenter({ variables })
+        .then(() => {
+          showToast({
+            variant: 'positive',
+            message: formatMessage(messages.toastUpdateSuccess),
+          })
+          refetch()
+          handleSetAddresses(newAddresses)
+          setLoadingState(false)
+          handleCloseModals()
+        })
+        .catch(error => {
+          console.error(error)
+          showToast({
+            variant: 'critical',
+            message: formatMessage(messages.toastUpdateFailure),
+          })
+          setLoadingState(false)
+        })
+
       setAddresses(
         newAddresses.map(item => {
           if (newAddressState.checked) {
@@ -342,9 +378,6 @@ const CostCenterDetails: FunctionComponent = () => {
           return item
         })
       )
-
-      setAddresses([...addresses, newAddress])
-      handleCloseModals()
     } else {
       showToast({
         variant: 'critical',
@@ -386,8 +419,41 @@ const CostCenterDetails: FunctionComponent = () => {
       addressQuery: editAddressState.addressQuery.value,
     }
 
-    setAddresses(addressArray)
-    handleCloseModals()
+    setLoadingState(true)
+
+    const variables = {
+      id: params.id,
+      input: {
+        addresses: addressArray
+          .sort(item => (item.checked ? -1 : 1))
+          .map(item => {
+            return {
+              ...item,
+              checked: undefined,
+            }
+          }),
+      },
+    }
+
+    updateCostCenter({ variables })
+      .then(() => {
+        showToast({
+          variant: 'positive',
+          message: formatMessage(messages.toastUpdateSuccess),
+        })
+        refetch()
+        handleSetAddresses(addressArray)
+        setLoadingState(false)
+        handleCloseModals()
+      })
+      .catch(error => {
+        console.error(error)
+        showToast({
+          variant: 'critical',
+          message: formatMessage(messages.toastUpdateFailure),
+        })
+        setLoadingState(false)
+      })
   }
 
   const handleDeleteAddress = () => {
@@ -399,8 +465,40 @@ const CostCenterDetails: FunctionComponent = () => {
     )
 
     addresses.splice(addressIndex, 1)
-    setAddresses(addressArray)
-    handleCloseModals()
+
+    setLoadingState(true)
+
+    const variables = {
+      id: params.id,
+      input: {
+        addresses: addresses.map(item => {
+          return {
+            ...item,
+            checked: undefined,
+          }
+        }),
+      },
+    }
+
+    updateCostCenter({ variables })
+      .then(() => {
+        showToast({
+          variant: 'positive',
+          message: formatMessage(messages.toastUpdateSuccess),
+        })
+        refetch()
+        handleSetAddresses(addressArray)
+        setLoadingState(false)
+        handleCloseModals()
+      })
+      .catch(error => {
+        console.error(error)
+        showToast({
+          variant: 'critical',
+          message: formatMessage(messages.toastUpdateFailure),
+        })
+        setLoadingState(false)
+      })
   }
 
   const handleMarketingTags = (tagValue: string) => {


### PR DESCRIPTION
What problem is this solving?
Previously it was not possible to save, edit and delete a new cost center address by confirming the addition in the modal

How to test it?
Log in to your store admin account, access the "aplicativos->organizações->centro de custos->Detalhes do centro de custo" page, enter a registered cost center and try to add or edit or delete an address.

[Workspace](https://josmar--b2bstore005.myvtex.com/admin/b2b-organizations/cost-centers/cc-org-test-3/)

Screenshots or example usage:
[Screen Recording 2024-05-28 at 15.53.55.zip](https://github.com/vtex-apps/b2b-organizations/files/15474680/Screen.Recording.2024-05-28.at.15.53.55.zip)

<img width="1440" alt="Screenshot 2024-05-28 at 15 59 26" src="https://github.com/vtex-apps/b2b-organizations/assets/72118355/5efd6d98-348c-41ff-9ddf-670e7f8998cf">
<img width="1440" alt="Screenshot 2024-05-28 at 15 59 06" src="https://github.com/vtex-apps/b2b-organizations/assets/72118355/cb7b016e-e96e-4a67-a310-80b9727f9c86">
<img width="1440" alt="Screenshot 2024-05-28 at 15 58 55" src="https://github.com/vtex-apps/b2b-organizations/assets/72118355/d8fadc40-be1b-4862-8fee-22f4457e3c03">
<img width="1440" alt="Screenshot 2024-05-28 at 15 58 49" src="https://github.com/vtex-apps/b2b-organizations/assets/72118355/416c3f20-d7b7-4a7d-ba0e-fc6730f9648a">

Describe alternatives you've considered, if any.
It is now possible for the user to save an address to the cost center immediately after adding, editing and deleting on admin

Related to / Depends on
How does this PR make you feel? [🔗](http://giphy.com/)
![](put .gif link here - can be found under "advanced" on giphy)