### PR TITLE
fix: Implement pagination for sellers in Organization Details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Implement pagination for sellers in Organization Details page
+
 ## [1.33.0] - 2024-07-18
 
 ### Feat

--- a/react/graphql/getSellersPaginated.graphql
+++ b/react/graphql/getSellersPaginated.graphql
@@ -1,0 +1,14 @@
+query GetSellersPaginated($page: Int, $pageSize: Int) {
+  getSellersPaginated(args: { page: $page, pageSize: $pageSize }) {
+    pagination {
+      page
+      pageSize
+      total
+    }
+    items {
+      id
+      name
+      email
+    }
+  }
+}

--- a/react/graphql/getSellersPaginated.graphql
+++ b/react/graphql/getSellersPaginated.graphql
@@ -1,5 +1,5 @@
 query GetSellersPaginated($page: Int, $pageSize: Int) {
-  getSellersPaginated(args: { page: $page, pageSize: $pageSize }) {
+  getSellersPaginated(page: $page, pageSize: $pageSize) {
     pagination {
       page
       pageSize


### PR DESCRIPTION
#### What problem is this solving?

On the B2B Organization Details Screen, the view of salespeople is limited to the first 100 records. This limit prevents users from selecting salespeople who are not among the first 100.

#### How to test it?

Go to Applications and in the ORGANIZATIONS AND B2B COST CENTERS subcategory and click on Organizations. Then, click on an Organization and go to the Sellers tab:

![image](https://github.com/user-attachments/assets/e01cd1c2-9ebc-43fa-8a73-bea9a727b48e)

[Workspace](https://icaroov--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/ac77fcd0-49c4-11ef-8452-0e41f4141887/#/sellers)

#### Screenshots or example usage:

![image](https://github.com/user-attachments/assets/2fdc6a58-121e-40e2-bdcc-0b7eb39b7526)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/5vD8o9XWJ5FLaHe8YP/giphy.gif?cid=82a1493bu6jz5kv34ppebodri283ha8cpmqnj66f9pw80guw&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
