### PR TITLE
fix: adjust pagination with `selectedOption` prop on Organizations Details pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update pagination selected option in Organization Details pages
+
 ## [1.34.0] - 2024-08-20
 
 ### Fixed

--- a/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCollections.tsx
@@ -178,6 +178,7 @@ const OrganizationDetailsCollections = ({
               onNextClick: handleCollectionsNextClick,
               onPrevClick: handleCollectionsPrevClick,
               onRowsChange: handleRowsChange,
+              selectedOption: collectionPaginationState.pageSize,
               currentItemFrom:
                 (collectionPaginationState.page - 1) *
                   collectionPaginationState.pageSize +

--- a/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
@@ -304,6 +304,7 @@ const OrganizationDetailsCostCenters = ({
             onNextClick: handleCostCentersNextClick,
             onPrevClick: handleCostCentersPrevClick,
             onRowsChange: handleCostCentersRowsChange,
+            selectedOption: costCenterPaginationState.pageSize,
             currentItemFrom:
               (costCenterPaginationState.page - 1) *
                 costCenterPaginationState.pageSize +

--- a/react/admin/OrganizationDetails/OrganizationDetailsSellers.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsSellers.tsx
@@ -178,6 +178,7 @@ const OrganizationDetailsSellers = ({
               onNextClick: handleNext,
               onPrevClick: handlePrev,
               onRowsChange: handleRowsChange,
+              selectedOption: variables.pageSize,
               currentItemFrom: (variables.page - 1) * variables.pageSize + 1,
               currentItemTo: Math.min(
                 variables.page * variables.pageSize,

--- a/react/admin/OrganizationRequestsTable.tsx
+++ b/react/admin/OrganizationRequestsTable.tsx
@@ -325,6 +325,7 @@ const OrganizationRequestsTable: FunctionComponent = () => {
           onNextClick: handleNextClick,
           onPrevClick: handlePrevClick,
           onRowsChange: handleRowsChange,
+          selectedOption: pageSize,
           currentItemFrom: (page - 1) * pageSize + 1,
           currentItemTo: total < page * pageSize ? total : page * pageSize,
           textShowRows: formatMessage(messages.showRows),

--- a/react/components/OrganizationsWithoutSalesManager.tsx
+++ b/react/components/OrganizationsWithoutSalesManager.tsx
@@ -139,6 +139,7 @@ const OrganizationsWithoutSalesManager = () => {
             pagination={{
               onNextClick: handleNextClick,
               onPrevClick: handlePrevClick,
+              selectedOption: paginationState.tableLength,
               currentItemFrom: paginationState.currentItemFrom,
               currentItemTo: paginationState.currentItemTo,
               onRowsChange: handleRowsChange,


### PR DESCRIPTION
#### What problem is this solving?

Update pagination selected option in Organization Details pages

#### How to test it?

Go to Admin -> Apps -> Organizations -> Sellers

![image](https://github.com/user-attachments/assets/e161aca4-8719-440a-9edb-81a1e94f0b60)


[Workspace](https://icaroov--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/ac77fcd0-49c4-11ef-8452-0e41f4141887/#/sellers)

#### Screenshots or example usage:


https://github.com/user-attachments/assets/63536aa9-0892-4646-9eaf-f56f179a673b

