### PR TITLE
Feat/create organization details settings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add new tab called 'settings' at organization details
+
 
 ## [1.35.1] - 2024-10-01
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "حفظ",
   "admin/b2b-organizations.organization-details.collections": "المجموعات",
   "admin/b2b-organizations.organization-details.costCenters": "مراكز التكلفة",
+  "admin/b2b-organizations.organization-details.settings": "الإعدادات",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "إنشاء عرض سعر",
   "admin/b2b-organizations.organization-details.created": "إنشاء",
   "admin/b2b-organizations.organization-details.default": "عــام",
   "admin/b2b-organizations.organization-details.edit-user": "تعديل المستخدم",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Запазване",
   "admin/b2b-organizations.organization-details.collections": "Колекции",
   "admin/b2b-organizations.organization-details.costCenters": "Разходни центрове",
+  "admin/b2b-organizations.organization-details.settings": "Настройки",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Създаване на оферта",
   "admin/b2b-organizations.organization-details.created": "Създадено",
   "admin/b2b-organizations.organization-details.default": "Общ",
   "admin/b2b-organizations.organization-details.edit-user": "Редактиране на потребител",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Desa",
   "admin/b2b-organizations.organization-details.collections": "Col·leccions",
   "admin/b2b-organizations.organization-details.costCenters": "Centres de costs",
+  "admin/b2b-organizations.organization-details.settings": "Configuració",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Crear pressupost",
   "admin/b2b-organizations.organization-details.created": "Creat",
   "admin/b2b-organizations.organization-details.default": "General",
   "admin/b2b-organizations.organization-details.edit-user": "Edita l'usuari",

--- a/messages/context.json
+++ b/messages/context.json
@@ -108,6 +108,8 @@
   "admin/b2b-organizations.of": "admin/b2b-organizations.of",
   "admin/b2b-organizations.organization-details.add-costCenter": "admin/b2b-organizations.organization-details.add-costCenter",
   "admin/b2b-organizations.organization-details.add-costCenter.helpText": "admin/b2b-organizations.organization-details.add-costCenter.helpText",
+  "admin/b2b-organizations.organization-details.settings": "admin/b2b-organizations.organization-details.settings",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "admin/b2b-organizations.organization-details.settings.createQuote",
   "admin/b2b-organizations.organization-details.add-to-org": "admin/b2b-organizations.organization-details.add-to-org",
   "admin/b2b-organizations.organization-details.add-user": "admin/b2b-organizations.organization-details.add-user",
   "admin/b2b-organizations.organization-details.add-user.helpText": "admin/b2b-organizations.organization-details.add-user.helpText",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Uložit",
   "admin/b2b-organizations.organization-details.collections": "Sbírky",
   "admin/b2b-organizations.organization-details.costCenters": "Nákladová střediska",
+  "admin/b2b-organizations.organization-details.settings": "Nastavení",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Vytvořit nabídku",
   "admin/b2b-organizations.organization-details.created": "Vytvořeno",
   "admin/b2b-organizations.organization-details.default": "Obecné",
   "admin/b2b-organizations.organization-details.edit-user": "Upravit uživatele",

--- a/messages/da.json
+++ b/messages/da.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Gem",
   "admin/b2b-organizations.organization-details.collections": "Kollektioner",
   "admin/b2b-organizations.organization-details.costCenters": "Omkostningscenter",
+  "admin/b2b-organizations.organization-details.settings": "Indstillinger",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Opret tilbud",
   "admin/b2b-organizations.organization-details.created": "Oprettet",
   "admin/b2b-organizations.organization-details.default": "Generelt",
   "admin/b2b-organizations.organization-details.edit-user": "Redigér bruger",

--- a/messages/de.json
+++ b/messages/de.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Speichern",
   "admin/b2b-organizations.organization-details.collections": "Kollektionen",
   "admin/b2b-organizations.organization-details.costCenters": "Kostenstellen",
+  "admin/b2b-organizations.organization-details.settings": "Einstellungen",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Angebot erstellen",
   "admin/b2b-organizations.organization-details.created": "Erstellt",
   "admin/b2b-organizations.organization-details.default": "Allgemein",
   "admin/b2b-organizations.organization-details.edit-user": "Benutzer bearbeiten",

--- a/messages/el.json
+++ b/messages/el.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Αποθήκευση",
   "admin/b2b-organizations.organization-details.collections": "Συλλογές",
   "admin/b2b-organizations.organization-details.costCenters": "Κέντρα κόστους",
+  "admin/b2b-organizations.organization-details.settings": "Ρυθμίσεις",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Δημιουργία προσφοράς",
   "admin/b2b-organizations.organization-details.created": "Δημιουργήθηκε",
   "admin/b2b-organizations.organization-details.default": "Γενικά",
   "admin/b2b-organizations.organization-details.edit-user": "Επεξεργασία χρήστη",

--- a/messages/en.json
+++ b/messages/en.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Save",
   "admin/b2b-organizations.organization-details.collections": "Collections",
   "admin/b2b-organizations.organization-details.costCenters": "Cost Centers",
+  "admin/b2b-organizations.organization-details.settings": "Settings",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Create quote",
   "admin/b2b-organizations.organization-details.created": "Created",
   "admin/b2b-organizations.organization-details.default": "General",
   "admin/b2b-organizations.organization-details.edit-user": "Edit User",

--- a/messages/es.json
+++ b/messages/es.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Guardar",
   "admin/b2b-organizations.organization-details.collections": "Colecciones",
   "admin/b2b-organizations.organization-details.costCenters": "Centros de costos",
+  "admin/b2b-organizations.organization-details.settings": "Configuración",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Crear cotización",
   "admin/b2b-organizations.organization-details.created": "Creada",
   "admin/b2b-organizations.organization-details.default": "General",
   "admin/b2b-organizations.organization-details.edit-user": "Editar usuario",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Tallenna",
   "admin/b2b-organizations.organization-details.collections": "Kokoelmat",
   "admin/b2b-organizations.organization-details.costCenters": "Kustannuspaikat",
+  "admin/b2b-organizations.organization-details.settings": "Asetukset",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Luo tarjous",
   "admin/b2b-organizations.organization-details.created": "Luotu",
   "admin/b2b-organizations.organization-details.default": "Yleiset",
   "admin/b2b-organizations.organization-details.edit-user": "Muokkaa käyttäjää",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Sauvegarder",
   "admin/b2b-organizations.organization-details.collections": "Collections",
   "admin/b2b-organizations.organization-details.costCenters": "Centres de coûts",
+  "admin/b2b-organizations.organization-details.settings": "Paramètres",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Créer un devis",
   "admin/b2b-organizations.organization-details.created": "Créée",
   "admin/b2b-organizations.organization-details.default": "Général",
   "admin/b2b-organizations.organization-details.edit-user": "Modifier l’utilisateur",

--- a/messages/id.json
+++ b/messages/id.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Simpan",
   "admin/b2b-organizations.organization-details.collections": "Pengumpulan",
   "admin/b2b-organizations.organization-details.costCenters": "Pusat Biaya",
+  "admin/b2b-organizations.organization-details.settings": "Pengaturan",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Buat kutipan",
   "admin/b2b-organizations.organization-details.created": "Dibuat",
   "admin/b2b-organizations.organization-details.default": "Umum",
   "admin/b2b-organizations.organization-details.edit-user": "Edit Pengguna",

--- a/messages/it.json
+++ b/messages/it.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Salva",
   "admin/b2b-organizations.organization-details.collections": "Collezioni",
   "admin/b2b-organizations.organization-details.costCenters": "Centri di costo",
+  "admin/b2b-organizations.organization-details.settings": "Impostazioni",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Crea preventivo",
   "admin/b2b-organizations.organization-details.created": "Creata",
   "admin/b2b-organizations.organization-details.default": "Generali",
   "admin/b2b-organizations.organization-details.edit-user": "Modifica utente",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "保存",
   "admin/b2b-organizations.organization-details.collections": "コレクション",
   "admin/b2b-organizations.organization-details.costCenters": "コストセンター",
+  "admin/b2b-organizations.organization-details.settings": "設定",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "見積もりを作成する",
   "admin/b2b-organizations.organization-details.created": "作成済み",
   "admin/b2b-organizations.organization-details.default": "全般",
   "admin/b2b-organizations.organization-details.edit-user": "ユーザーを編集する",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "저장",
   "admin/b2b-organizations.organization-details.collections": "컬렉션",
   "admin/b2b-organizations.organization-details.costCenters": "비용 센터",
+  "admin/b2b-organizations.organization-details.settings": "설정",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "견적 생성",
   "admin/b2b-organizations.organization-details.created": "생성됨",
   "admin/b2b-organizations.organization-details.default": "일반",
   "admin/b2b-organizations.organization-details.edit-user": "사용자 편집",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Opslaan",
   "admin/b2b-organizations.organization-details.collections": "Collecties",
   "admin/b2b-organizations.organization-details.costCenters": "Kostencentra",
+  "admin/b2b-organizations.organization-details.settings": "Instellingen",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Offerte maken",
   "admin/b2b-organizations.organization-details.created": "Gecreëerd",
   "admin/b2b-organizations.organization-details.default": "Algemeen",
   "admin/b2b-organizations.organization-details.edit-user": "Gebruiker bewerken",

--- a/messages/no.json
+++ b/messages/no.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Lagre",
   "admin/b2b-organizations.organization-details.collections": "Samlinger",
   "admin/b2b-organizations.organization-details.costCenters": "Kostnadssentre",
+  "admin/b2b-organizations.organization-details.settings": "Innstillinger",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Opprett tilbud",
   "admin/b2b-organizations.organization-details.created": "Opprettet",
   "admin/b2b-organizations.organization-details.default": "Generell",
   "admin/b2b-organizations.organization-details.edit-user": "Rediger bruker",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Zapisz",
   "admin/b2b-organizations.organization-details.collections": "Kolekcje",
   "admin/b2b-organizations.organization-details.costCenters": "Centra kosztów",
+  "admin/b2b-organizations.organization-details.settings": "Ustawienia",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Utwórz ofertę",
   "admin/b2b-organizations.organization-details.created": "Utworzone",
   "admin/b2b-organizations.organization-details.default": "Ogólna",
   "admin/b2b-organizations.organization-details.edit-user": "Edytuj użytkownika",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Salvar",
   "admin/b2b-organizations.organization-details.collections": "Coleções",
   "admin/b2b-organizations.organization-details.costCenters": "Centros de custo",
+  "admin/b2b-organizations.organization-details.settings": "Configurações",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Criar cota",
   "admin/b2b-organizations.organization-details.created": "Criado",
   "admin/b2b-organizations.organization-details.default": "Gerais",
   "admin/b2b-organizations.organization-details.edit-user": "Editar usuário",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Salvează",
   "admin/b2b-organizations.organization-details.collections": "Colecții",
   "admin/b2b-organizations.organization-details.costCenters": "Centru de cost",
+  "admin/b2b-organizations.organization-details.settings": "Setări",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Crează ofertă",
   "admin/b2b-organizations.organization-details.created": "Creată",
   "admin/b2b-organizations.organization-details.default": "General",
   "admin/b2b-organizations.organization-details.edit-user": "Editează utilizatorul",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Сохранить",
   "admin/b2b-organizations.organization-details.collections": "Коллекции",
   "admin/b2b-organizations.organization-details.costCenters": "Финансовые центры",
+  "admin/b2b-organizations.organization-details.settings": "Настройки",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Создать котировку",
   "admin/b2b-organizations.organization-details.created": "Создано",
   "admin/b2b-organizations.organization-details.default": "Общее",
   "admin/b2b-organizations.organization-details.edit-user": "Редактировать пользователя",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Uložiť",
   "admin/b2b-organizations.organization-details.collections": "Vyzdvihnutia",
   "admin/b2b-organizations.organization-details.costCenters": "Nákladové strediská",
+  "admin/b2b-organizations.organization-details.settings": "Nastavenia",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Vytvoriť ponuku",
   "admin/b2b-organizations.organization-details.created": "Vytvorené",
   "admin/b2b-organizations.organization-details.default": "Všeobecné",
   "admin/b2b-organizations.organization-details.edit-user": "Upraviť používateľa",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Shrani",
   "admin/b2b-organizations.organization-details.collections": "Zbirke",
   "admin/b2b-organizations.organization-details.costCenters": "Stroškovna mesta",
+  "admin/b2b-organizations.organization-details.settings": "Nastavitve",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Ustvari ponudbo",
   "admin/b2b-organizations.organization-details.created": "Ustvarjeno",
   "admin/b2b-organizations.organization-details.default": "Splošno",
   "admin/b2b-organizations.organization-details.edit-user": "Uredi uporabnika",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Spara",
   "admin/b2b-organizations.organization-details.collections": "Samlingar",
   "admin/b2b-organizations.organization-details.costCenters": "Kostnadsställe",
+  "admin/b2b-organizations.organization-details.settings": "Inställningar",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Skapa offert",
   "admin/b2b-organizations.organization-details.created": "Skapad",
   "admin/b2b-organizations.organization-details.default": "Allmänt",
   "admin/b2b-organizations.organization-details.edit-user": "Ändra användare",

--- a/messages/th.json
+++ b/messages/th.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "บันทึก",
   "admin/b2b-organizations.organization-details.collections": "คอลเล็กชัน",
   "admin/b2b-organizations.organization-details.costCenters": "ศูนย์ต้นทุน",
+  "admin/b2b-organizations.organization-details.settings": "การตั้งค่า",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "สร้างใบเสนอราคา",
   "admin/b2b-organizations.organization-details.created": "สร้างแล้ว",
   "admin/b2b-organizations.organization-details.default": "ทั่วไป",
   "admin/b2b-organizations.organization-details.edit-user": "แก้ไขผู้ใช้",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -121,6 +121,8 @@
   "admin/b2b-organizations.organization-details.button.save": "Зберегти",
   "admin/b2b-organizations.organization-details.collections": "Колекції",
   "admin/b2b-organizations.organization-details.costCenters": "Фінансові центри",
+  "admin/b2b-organizations.organization-details.settings": "Налаштування",
+  "admin/b2b-organizations.organization-details.settings.createQuote": "Створити котирування",
   "admin/b2b-organizations.organization-details.created": "Створено",
   "admin/b2b-organizations.organization-details.default": "Загальне",
   "admin/b2b-organizations.organization-details.edit-user": "Редагувати користувача",

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -436,7 +436,7 @@ const OrganizationDetails: FunctionComponent = () => {
       ),
     },
     {
-      label: 'Configurações',
+      label: formatMessage(messages.settings),
       tab: 'settings',
       component: (
         <OrganizationDetailsSettings

--- a/react/admin/OrganizationDetails.tsx
+++ b/react/admin/OrganizationDetails.tsx
@@ -35,6 +35,8 @@ import OrganizationDetailsDefault from './OrganizationDetails/OrganizationDetail
 import useHashRouter from './OrganizationDetails/useHashRouter'
 import type { Seller } from './OrganizationDetails/OrganizationDetailsSellers'
 import OrganizationDetailsSellers from './OrganizationDetails/OrganizationDetailsSellers'
+import type { PermissionsOptions } from './OrganizationDetails/OrganizationDetailsSettings'
+import OrganizationDetailsSettings from './OrganizationDetails/OrganizationDetailsSettings'
 
 export interface CellRendererProps<RowType> {
   cellData: unknown
@@ -89,6 +91,10 @@ const OrganizationDetails: FunctionComponent = () => {
     [] as PaymentTerm[]
   )
 
+  const [permissionsOptions, setPermissionsOptions] = useState(
+    [] as PermissionsOptions[]
+  )
+
   // const routerRef = useRef(null as any)
 
   const [loadingState, setLoadingState] = useState(false)
@@ -102,6 +108,24 @@ const OrganizationDetails: FunctionComponent = () => {
     variables: { id: params?.id },
     skip: !params?.id,
     ssr: false,
+    onCompleted(insideData) {
+      if (!insideData?.getOrganizationById?.permissions) {
+        return
+      }
+
+      const permissionsArray = Object.entries(
+        insideData.getOrganizationById.permissions
+      ).filter(key => {
+        return !(key[0] === '__typename')
+      })
+
+      setPermissionsOptions(() => {
+        return permissionsArray.map(p => ({
+          label: p[0],
+          value: p[1] as boolean,
+        }))
+      })
+    },
   })
 
   const { data: defaultCustomFieldsData } = useQuery(GET_B2B_CUSTOM_FIELDS, {
@@ -151,6 +175,11 @@ const OrganizationDetails: FunctionComponent = () => {
         id: seller.sellerId,
         name: seller.name,
       })),
+      permissions: permissionsOptions.reduce((acc, current) => {
+        acc[current.label] = current.value
+
+        return acc
+      }, {} as Record<string, boolean>),
     }
 
     updateOrganization({ variables })
@@ -404,6 +433,16 @@ const OrganizationDetails: FunctionComponent = () => {
       tab: 'users',
       component: (
         <OrganizationDetailsUsers params={params} loadingState={loadingState} />
+      ),
+    },
+    {
+      label: 'Configurações',
+      tab: 'settings',
+      component: (
+        <OrganizationDetailsSettings
+          permissionsOptions={permissionsOptions}
+          setPermissionsOptions={setPermissionsOptions}
+        />
       ),
     },
   ]

--- a/react/admin/OrganizationDetails/OrganizationDetailsSettings.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsSettings.tsx
@@ -1,5 +1,8 @@
 import { PageBlock, Checkbox } from 'vtex.styleguide'
 import React, { Fragment } from 'react'
+import { useIntl } from 'react-intl'
+
+import { organizationMessages as messages } from '../utils/messages'
 
 export interface PermissionsOptions {
   value: boolean
@@ -15,14 +18,16 @@ interface OrganizationDetailsSettingsProps {
   >
 }
 
-const simulateTranslate: Record<Permission, string> = {
-  createQuote: 'Criar cota',
-}
-
 const OrganizationDetailsSettings = ({
   permissionsOptions,
   setPermissionsOptions,
 }: OrganizationDetailsSettingsProps) => {
+  const { formatMessage } = useIntl()
+
+  const simulateTranslate: Record<Permission, string> = {
+    createQuote: formatMessage(messages.createQuote),
+  }
+
   const handleCheckboxChange = (label: string) => {
     setPermissionsOptions(prevOptions =>
       prevOptions.map(option =>

--- a/react/admin/OrganizationDetails/OrganizationDetailsSettings.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsSettings.tsx
@@ -1,0 +1,53 @@
+import { PageBlock, Checkbox } from 'vtex.styleguide'
+import React, { Fragment } from 'react'
+
+export interface PermissionsOptions {
+  value: boolean
+  label: string
+}
+
+type Permission = 'createQuote'
+
+interface OrganizationDetailsSettingsProps {
+  permissionsOptions: PermissionsOptions[]
+  setPermissionsOptions: React.Dispatch<
+    React.SetStateAction<PermissionsOptions[]>
+  >
+}
+
+const simulateTranslate: Record<Permission, string> = {
+  createQuote: 'Criar cota',
+}
+
+const OrganizationDetailsSettings = ({
+  permissionsOptions,
+  setPermissionsOptions,
+}: OrganizationDetailsSettingsProps) => {
+  const handleCheckboxChange = (label: string) => {
+    setPermissionsOptions(prevOptions =>
+      prevOptions.map(option =>
+        option.label === label ? { ...option, value: !option.value } : option
+      )
+    )
+  }
+
+  return (
+    <Fragment>
+      <PageBlock title="Configurações de permissão">
+        {permissionsOptions.map(permissionOption => (
+          <div>
+            <Checkbox
+              checked={permissionOption.value}
+              id="permissionOrganization"
+              name="permissionOrganization"
+              onChange={() => handleCheckboxChange(permissionOption.label)}
+              label={simulateTranslate[permissionOption.label as Permission]}
+            />
+          </div>
+        ))}
+      </PageBlock>
+    </Fragment>
+  )
+}
+
+export default OrganizationDetailsSettings

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -42,6 +42,12 @@ export const organizationMessages = defineMessages({
   costCenters: {
     id: `${adminPrefix}organization-details.costCenters`,
   },
+  settings: {
+    id: `${adminPrefix}organization-details.settings`,
+  },
+  createQuote: {
+    id: `${adminPrefix}organization-details.settings.createQuote`,
+  },
   showRows: {
     id: `${adminPrefix}showRows`,
   },

--- a/react/graphql/getOrganization.graphql
+++ b/react/graphql/getOrganization.graphql
@@ -31,5 +31,8 @@ query GetOrganization($id: ID) {
       }
       useOnRegistration
     }
+    permissions {
+      createQuote
+    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Before, it wasn't possible to manipulate the creation of quote permission at an organization. Has now been added a new tab that is called 'Configurações'and it is possible to change the state permission to true or false.

<!--- What is the motivation and context for this change? -->
be possible to manipulate the create quote permission at an organization

#### How to test it?
1. Enter the URL [https://giubernal--b2bstore005.myvtex.com/admin](https://giubernal--b2bstore005.myvtex.com/admin)
2. Open the sidebar -> click at 'aplicativos' -> go to 'Organizações'
3. On the organizations' screen, select the current organization of the user logged in to the store
4. After that select the 'Configurações' and you will see 'Criar cota'
5. Active or disabled the checkbox and click at the save button

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[https://giubernal--b2bstore005.myvtex.com/admin](https://giubernal--b2bstore005.myvtex.com/admin)

#### Screenshots or example usage:
<img width="1429" alt="Screenshot 2024-09-09 at 11 31 31" src="https://github.com/user-attachments/assets/f3ce0a76-1434-42e4-8034-0496cf6c494a">

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [5aWQwYTYyZWdhbDR4c3E2MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tqj4m9BRURayxQAIW9/giphy.gif)](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGFhNTd2ZjdsOTVjOTVraWthN2p1ajA5aWQwYTYyZWdhbDR4c3E2MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tqj4m9BRURayxQAIW9/giphy.gif)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
