### PR TITLE
Added Organization Setting "Full Impersonation" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Full Impersonation` Organization Setting, this will allow a Impersonator to also Switch between the User's Organization/Cost Center
+
 ## [1.35.1] - 2024-10-01
 
 ## [1.35.0] - 2024-09-10
 
 ### Added
+
 - Added `getAccount` query on OrganizationDetailsSellers component to get the account data
 
 ## [1.34.3] - 2024-09-05
 
 ### Fixed
+
 - Review and reorder translations for better maintainability
 
 ## [1.34.2] - 2024-09-03
@@ -34,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.34.0] - 2024-08-20
 
 ### Fixed
+
 - Implement pagination for sellers in Organization Details page
 
 ## [1.33.1] - 2024-08-06
@@ -63,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Implement 'none' option at trade policy organization
 
 ## [1.31.9] - 2024-06-20
+
 ### Fixed
 
 - Adjusts list organization and research screening according to input at autocomplete
@@ -74,6 +82,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.31.6] - 2024-05-28
 
 ## [1.31.5] - 2024-05-28
+
 ### Fixed
 
 - Save new address within the Cost Center in the store

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "تم تحديث الإعدادات بنجاح",
   "admin/b2b-organizations.organization-settings-autoApprove": "الموافقة على المنظمات الجديدة تلقائياً",
   "admin/b2b-organizations.organization-settings-clearCart": "امسح سلة التسوق عند تبديل الشركة أو تسجيل الدخول",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "التمثيل الكامل",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "السماح باختيار المؤسسة ومركز التكلفة أثناء الانتحال",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "إضافة إلى الربط",
   "admin/b2b-organizations.organization-settings-select.binding.available": "الروابط المتاحة",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "الروابط المختارة",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "تم تحديث الإعدادات بنجاح",
   "admin/b2b-organizations.organization-settings-autoApprove": "الموافقة على المنظمات الجديدة تلقائياً",
   "admin/b2b-organizations.organization-settings-clearCart": "امسح سلة التسوق عند تبديل الشركة أو تسجيل الدخول",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "التمثيل الكامل",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "إضافة إلى الربط",
   "admin/b2b-organizations.organization-settings-select.binding.available": "الروابط المتاحة",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "الروابط المختارة",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Настройките са актуализирани успешно",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматично одобряване на нови организации",
   "admin/b2b-organizations.organization-settings-clearCart": "Изчистване на количката при смяна на компанията или влизане",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "пълно представяне",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Добавяне към обвързване",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Налични обвързвания",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Избрани обвързвания",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Настройките са актуализирани успешно",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматично одобряване на нови организации",
   "admin/b2b-organizations.organization-settings-clearCart": "Изчистване на количката при смяна на компанията или влизане",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "пълно представяне",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Позволяване на избор на организация и разходен център при империране",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Добавяне към обвързване",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Налични обвързвания",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Избрани обвързвания",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "S'ha actualitzat correctament la configuració",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprova automàticament les organitzacions noves",
   "admin/b2b-organizations.organization-settings-clearCart": "Esborra el carretó en canviar d'empresa o iniciar la sessió",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Impersonació completa",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Permet la selecció d’Organització i Centre de Cost mentre s’està suplantant",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Afegeix-ho a la vinculació",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vinculacions disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vinculacions seleccionades",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "S'ha actualitzat correctament la configuració",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprova automàticament les organitzacions noves",
   "admin/b2b-organizations.organization-settings-clearCart": "Esborra el carretó en canviar d'empresa o iniciar la sessió",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Impersonació completa",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Afegeix-ho a la vinculació",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vinculacions disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vinculacions seleccionades",

--- a/messages/context.json
+++ b/messages/context.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "admin/b2b-organizations.organization-settings-admin.toast.update-success",
   "admin/b2b-organizations.organization-settings-autoApprove": "admin/b2b-organizations.organization-settings-autoApprove",
   "admin/b2b-organizations.organization-settings-clearCart": "admin/b2b-organizations.organization-settings-clearCart",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "admin/b2b-organizations.organization-settings-fullImpersonation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "admin/b2b-organizations.organization-settings-select.add-to-binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "admin/b2b-organizations.organization-settings-select.binding.available",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "admin/b2b-organizations.organization-settings-select.binding.selected",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavení bylo úspěšně aktualizováno",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatické schvalování nových organizací",
   "admin/b2b-organizations.organization-settings-clearCart": "Vyprázdnit košík při změně společnosti nebo přihlášení",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Přepínání mezi organizacemi",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Přidat do vazby",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostupné vazby",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vybrané vazby",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavení bylo úspěšně aktualizováno",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatické schvalování nových organizací",
   "admin/b2b-organizations.organization-settings-clearCart": "Vyprázdnit košík při změně společnosti nebo přihlášení",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Přepínání mezi organizacemi",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Povolit výběr organizace a nákladového střediska během impersonace",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Přidat do vazby",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostupné vazby",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vybrané vazby",

--- a/messages/da.json
+++ b/messages/da.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Indstillinger opdateret succesfuldt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkend nye organisationer automatisk",
   "admin/b2b-organizations.organization-settings-clearCart": "Ryd indkøbskurven, når du skifter virksomhed eller logger ind",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Fuldstændig personificering",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Tillad valg af organisation og omkostningscenter under imitation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Føj til binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tilgængelige bindinger",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valgte bindinger",

--- a/messages/da.json
+++ b/messages/da.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Indstillinger opdateret succesfuldt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkend nye organisationer automatisk",
   "admin/b2b-organizations.organization-settings-clearCart": "Ryd indkøbskurven, når du skifter virksomhed eller logger ind",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Fuldstændig personificering",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Føj til binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tilgængelige bindinger",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valgte bindinger",

--- a/messages/de.json
+++ b/messages/de.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Einstellungen erfolgreich aktualisiert",
   "admin/b2b-organizations.organization-settings-autoApprove": "Neue Organisationen automatisch genehmigen",
   "admin/b2b-organizations.organization-settings-clearCart": "Warenkorb löschen, wenn Sie das Unternehmen wechseln oder sich anmelden",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Vollständiger Identitätswechsel",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Erlaube die Auswahl von Organisation und Kostenstelle während der Imitation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Zur Bindung hinzufügen",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Verfügbare Bindungen",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Ausgewählte Bindungen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Einstellungen erfolgreich aktualisiert",
   "admin/b2b-organizations.organization-settings-autoApprove": "Neue Organisationen automatisch genehmigen",
   "admin/b2b-organizations.organization-settings-clearCart": "Warenkorb löschen, wenn Sie das Unternehmen wechseln oder sich anmelden",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Vollständiger Identitätswechsel",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Zur Bindung hinzufügen",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Verfügbare Bindungen",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Ausgewählte Bindungen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Οι ρυθμίσεις ενημερωθηκαν επιτυχώς",
   "admin/b2b-organizations.organization-settings-autoApprove": "Αυτόματη έγκριση νέων οργανισμών",
   "admin/b2b-organizations.organization-settings-clearCart": "Εκκαθάριση καλαθιού κατά την εναλλαγή εταιρείας ή την είσοδο",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Πλήρης πλαστοπροσωπία",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Προσθήκη στις δεσμεύσεις",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Διαθέσιμες δεσμεύσεις",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Επιλεγμένες δεσμεύσεις",

--- a/messages/el.json
+++ b/messages/el.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Οι ρυθμίσεις ενημερωθηκαν επιτυχώς",
   "admin/b2b-organizations.organization-settings-autoApprove": "Αυτόματη έγκριση νέων οργανισμών",
   "admin/b2b-organizations.organization-settings-clearCart": "Εκκαθάριση καλαθιού κατά την εναλλαγή εταιρείας ή την είσοδο",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Πλήρης πλαστοπροσωπία",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Επιτρέψτε την επιλογή Οργάνωσης και Κέντρου Κόστους κατά την μίμηση",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Προσθήκη στις δεσμεύσεις",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Διαθέσιμες δεσμεύσεις",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Επιλεγμένες δεσμεύσεις",

--- a/messages/en.json
+++ b/messages/en.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Settings updated successfully",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approve new organizations automatically",
   "admin/b2b-organizations.organization-settings-clearCart": "Clear cart when switching company or logging in",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Full impersonation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Add to binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Available bindings",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Selected bindings",

--- a/messages/en.json
+++ b/messages/en.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Settings updated successfully",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approve new organizations automatically",
   "admin/b2b-organizations.organization-settings-clearCart": "Clear cart when switching company or logging in",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Full impersonation",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Allow Organization and Cost Center selection while impersonating",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Add to binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Available bindings",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Selected bindings",

--- a/messages/es.json
+++ b/messages/es.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Configuración actualizada con éxito",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprobar nuevas organizaciones automáticamente",
   "admin/b2b-organizations.organization-settings-clearCart": "Limpiar carrito al cambiar de empresa o iniciar sesión",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Suplantación completa",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Permitir la selección de Organización y Centro de Costos mientras se suplanta",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Agregar al vínculo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vínculos disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vínculos seleccionados",

--- a/messages/es.json
+++ b/messages/es.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Configuración actualizada con éxito",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprobar nuevas organizaciones automáticamente",
   "admin/b2b-organizations.organization-settings-clearCart": "Limpiar carrito al cambiar de empresa o iniciar sesión",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Suplantación completa",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Agregar al vínculo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vínculos disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vínculos seleccionados",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Asetukset päivitetty onnistuneesti",
   "admin/b2b-organizations.organization-settings-autoApprove": "Hyväksy uudet organisaatiot automaattisesti",
   "admin/b2b-organizations.organization-settings-clearCart": "Tyhjennä ostoskori vaihdettaessa yritystä tai kirjauduttaessa sisään",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "täydellinen henkilönä esiintyminen",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Lisää sidokseen",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Saatavilla olevat sidokset",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valitut sidokset",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Asetukset päivitetty onnistuneesti",
   "admin/b2b-organizations.organization-settings-autoApprove": "Hyväksy uudet organisaatiot automaattisesti",
   "admin/b2b-organizations.organization-settings-clearCart": "Tyhjennä ostoskori vaihdettaessa yritystä tai kirjauduttaessa sisään",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "täydellinen henkilönä esiintyminen",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Salli organisaation ja kustannuspaikan valinta jäljiteltäessä",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Lisää sidokseen",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Saatavilla olevat sidokset",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valitut sidokset",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Paramètres mis à jour avec succès",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approuver automatiquement les nouvelles organisations",
   "admin/b2b-organizations.organization-settings-clearCart": "Vider le panier lors du changement d'entreprise ou de connexion",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Usurpation d'identité complète",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Permettre la sélection de l’Organisation et du Centre de Coûts lors de l’imitation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Ajouter à la liaison",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Liaisons disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Liaisons sélectionnées",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Paramètres mis à jour avec succès",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approuver automatiquement les nouvelles organisations",
   "admin/b2b-organizations.organization-settings-clearCart": "Vider le panier lors du changement d'entreprise ou de connexion",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Usurpation d'identité complète",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Ajouter à la liaison",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Liaisons disponibles",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Liaisons sélectionnées",

--- a/messages/id.json
+++ b/messages/id.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Seting berhasil disimpan",
   "admin/b2b-organizations.organization-settings-autoApprove": "Setujui organisasi baru secara otomatis",
   "admin/b2b-organizations.organization-settings-clearCart": "Kosongkan troli saat berganti perusahaan atau saat masuk",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Peniruan identitas penuh",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Izinkan pemilihan Organisasi dan Pusat Biaya saat melakukan peniruan",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Tambah ke binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Binding yang tersedia",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Binding yang dipilih",

--- a/messages/id.json
+++ b/messages/id.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Seting berhasil disimpan",
   "admin/b2b-organizations.organization-settings-autoApprove": "Setujui organisasi baru secara otomatis",
   "admin/b2b-organizations.organization-settings-clearCart": "Kosongkan troli saat berganti perusahaan atau saat masuk",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Peniruan identitas penuh",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Tambah ke binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Binding yang tersedia",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Binding yang dipilih",

--- a/messages/it.json
+++ b/messages/it.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Impostazioni aggiornate correttamente",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approva automaticamente le nuove organizzazioni",
   "admin/b2b-organizations.organization-settings-clearCart": "Svuota il carrello quando cambi azienda o effettui l'accesso",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Impersonificazione completa",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Consenti la selezione dell’Organizzazione e del Centro di Costo durante l’imitazione",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Aggiungi all'associazione",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Associazioni disponibili",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Associazioni selezionate",

--- a/messages/it.json
+++ b/messages/it.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Impostazioni aggiornate correttamente",
   "admin/b2b-organizations.organization-settings-autoApprove": "Approva automaticamente le nuove organizzazioni",
   "admin/b2b-organizations.organization-settings-clearCart": "Svuota il carrello quando cambi azienda o effettui l'accesso",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Impersonificazione completa",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Aggiungi all'associazione",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Associazioni disponibili",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Associazioni selezionate",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "設定の更新が成功しました",
   "admin/b2b-organizations.organization-settings-autoApprove": "新しい組織を自動的に承認する",
   "admin/b2b-organizations.organization-settings-clearCart": "会社の切り替え時やログイン時にカートをクリアする",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "フルインパーソネーション",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Add to binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Available bindings",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Selected bindings",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "設定の更新が成功しました",
   "admin/b2b-organizations.organization-settings-autoApprove": "新しい組織を自動的に承認する",
   "admin/b2b-organizations.organization-settings-clearCart": "会社の切り替え時やログイン時にカートをクリアする",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "フルインパーソネーション",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "偽装中に組織とコストセンターの選択を許可する",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Add to binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Available bindings",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Selected bindings",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "설정이 성공적으로 업데이트되었습니다.",
   "admin/b2b-organizations.organization-settings-autoApprove": "새 조직 자동 승인",
   "admin/b2b-organizations.organization-settings-clearCart": "회사 전환 또는 로그인 시 장바구니 지우기",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "완전한 사칭",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "바인딩에 추가",
   "admin/b2b-organizations.organization-settings-select.binding.available": "사용 가능한 바인딩",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "선택한 바인딩",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "설정이 성공적으로 업데이트되었습니다.",
   "admin/b2b-organizations.organization-settings-autoApprove": "새 조직 자동 승인",
   "admin/b2b-organizations.organization-settings-clearCart": "회사 전환 또는 로그인 시 장바구니 지우기",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "완전한 사칭",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "임시로 가장하는 동안 조직 및 비용 센터 선택 허용",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "바인딩에 추가",
   "admin/b2b-organizations.organization-settings-select.binding.available": "사용 가능한 바인딩",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "선택한 바인딩",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Instellingen zijn met succes bijgewerkt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatisch nieuwe organisaties goedkeuren",
   "admin/b2b-organizations.organization-settings-clearCart": "Winkelwagen leegmaken wanneer u van bedrijf wisselt of inlogt",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Volledige impersonatie",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Toestaan dat Organisatie en Kostenplaats geselecteerd worden tijdens impersonatie",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Toevoegen aan binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Beschikbare bindingen",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Geselecteerde bindingen",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Instellingen zijn met succes bijgewerkt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatisch nieuwe organisaties goedkeuren",
   "admin/b2b-organizations.organization-settings-clearCart": "Winkelwagen leegmaken wanneer u van bedrijf wisselt of inlogt",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Volledige impersonatie",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Toevoegen aan binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Beschikbare bindingen",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Geselecteerde bindingen",

--- a/messages/no.json
+++ b/messages/no.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Innstillingene er oppdatert",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkjenn nye organisasjoner automatisk",
   "admin/b2b-organizations.organization-settings-clearCart": "Tøm handlekurven når du bytter selskap eller logger inn",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Full personifisering",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Tillat valg av organisasjon og kostnadssenter under imitasjon",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Legg til i binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tilgjengelige bindinger",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valgte bindinger",

--- a/messages/no.json
+++ b/messages/no.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Innstillingene er oppdatert",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkjenn nye organisasjoner automatisk",
   "admin/b2b-organizations.organization-settings-clearCart": "Tøm handlekurven når du bytter selskap eller logger inn",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Full personifisering",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Legg til i binding",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tilgjengelige bindinger",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Valgte bindinger",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Pomyślnie zaktualizowano ustawienia",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatycznie zatwierdzaj nowe organizacje",
   "admin/b2b-organizations.organization-settings-clearCart": "Wyczyść koszyk podczas zmiany firmy lub logowania",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Pełna imitacja",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Zezwól na wybór organizacji i centrum kosztów podczas imitacji",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Dodaj do powiązania",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostępne powiązania",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Wybrane powiązania",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Pomyślnie zaktualizowano ustawienia",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatycznie zatwierdzaj nowe organizacje",
   "admin/b2b-organizations.organization-settings-clearCart": "Wyczyść koszyk podczas zmiany firmy lub logowania",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Pełna imitacja",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Dodaj do powiązania",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostępne powiązania",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Wybrane powiązania",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Configurações atualizadas com sucesso",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprovar novas organizações automaticamente",
   "admin/b2b-organizations.organization-settings-clearCart": "Limpar carrinho ao trocar de empresa ou fazer login",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Personificação completa",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Adicionar ao vínculo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vínculos disponíveis",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vínculos selecionados",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Configurações atualizadas com sucesso",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprovar novas organizações automaticamente",
   "admin/b2b-organizations.organization-settings-clearCart": "Limpar carrinho ao trocar de empresa ou fazer login",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Personificação completa",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Permitir a seleção de Organização e Centro de Custo durante a personificação",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Adicionar ao vínculo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vínculos disponíveis",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vínculos selecionados",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Setările au fost actualizate cu succes",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprobă automat noile organizații",
   "admin/b2b-organizations.organization-settings-clearCart": "Golește coșul atunci când se schimbă compania sau la autentificare",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Uzurparea identității deplină",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Permite selecția Organizației și Centrului de Cost în timpul imitației",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Adaugă la legătură",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Legături disponibile",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Legături selectate",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Setările au fost actualizate cu succes",
   "admin/b2b-organizations.organization-settings-autoApprove": "Aprobă automat noile organizații",
   "admin/b2b-organizations.organization-settings-clearCart": "Golește coșul atunci când se schimbă compania sau la autentificare",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Uzurparea identității deplină",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Adaugă la legătură",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Legături disponibile",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Legături selectate",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Настройки обновлены",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматически подтверждать новые организации",
   "admin/b2b-organizations.organization-settings-clearCart": "Очищать корзину при переключении компании или входе в систему",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Полное олицетворение",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Разрешить выбор организации и центра затрат во время имитации",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Добавить к привязкам",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Доступные привязки",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Выбранные привязки",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Настройки обновлены",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматически подтверждать новые организации",
   "admin/b2b-organizations.organization-settings-clearCart": "Очищать корзину при переключении компании или входе в систему",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Полное олицетворение",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Добавить к привязкам",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Доступные привязки",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Выбранные привязки",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavenia boli úspešne aktualizované",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatické schvaľovanie nových organizácií",
   "admin/b2b-organizations.organization-settings-clearCart": "Vymazať košík pri zmene spoločnosti alebo prihlásení",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Plné zastúpenie",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Povoliť výber organizácie a nákladového strediska počas imitácie",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Pridať do väzby",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostupné väzby",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vybrané väzby",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavenia boli úspešne aktualizované",
   "admin/b2b-organizations.organization-settings-autoApprove": "Automatické schvaľovanie nových organizácií",
   "admin/b2b-organizations.organization-settings-clearCart": "Vymazať košík pri zmene spoločnosti alebo prihlásení",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Plné zastúpenie",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Pridať do väzby",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Dostupné väzby",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Vybrané väzby",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavitve uspešno posodobljene",
   "admin/b2b-organizations.organization-settings-autoApprove": "Samodejno odobravanje novih organizacij",
   "admin/b2b-organizations.organization-settings-clearCart": "Izbriši košarico, ko zamenjaš podjetje ali se prijaviš",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Popolna lažna predstavitev",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Dovoli izbiro organizacije in stroškovnega centra med imitacijo",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Dodaj vezavo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vezave na voljo",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Izbrane vezave",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Nastavitve uspešno posodobljene",
   "admin/b2b-organizations.organization-settings-autoApprove": "Samodejno odobravanje novih organizacij",
   "admin/b2b-organizations.organization-settings-clearCart": "Izbriši košarico, ko zamenjaš podjetje ali se prijaviš",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Popolna lažna predstavitev",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Dodaj vezavo",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Vezave na voljo",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Izbrane vezave",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Inställningarna uppdaterades framgångsrikt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkänn nya organisationer automatiskt",
   "admin/b2b-organizations.organization-settings-clearCart": "Rensa kundvagn när du byter företag eller loggar in",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Fullständig identitetsstöld",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Tillåt val av organisation och kostnadscenter under imitation",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Lägg till i bindning",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tillgängliga bindningar",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Utvalda bindningar",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Inställningarna uppdaterades framgångsrikt",
   "admin/b2b-organizations.organization-settings-autoApprove": "Godkänn nya organisationer automatiskt",
   "admin/b2b-organizations.organization-settings-clearCart": "Rensa kundvagn när du byter företag eller loggar in",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Fullständig identitetsstöld",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Lägg till i bindning",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Tillgängliga bindningar",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Utvalda bindningar",

--- a/messages/th.json
+++ b/messages/th.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "อัปเดตการตั้งค่าเรียบร้อยแล้ว",
   "admin/b2b-organizations.organization-settings-autoApprove": "อนุมัติองค์กรใหม่โดยอัตโนมัติ",
   "admin/b2b-organizations.organization-settings-clearCart": "เคลียร์ล้อเข็นเมื่อเปลี่ยนบริษัทหรือเข้าสู่ระบบ",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "การปลอมตัวเต็มรูปแบบ",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "อนุญาตให้เลือกองค์กรและศูนย์ต้นทุนในขณะที่เลียนแบบ",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "เพิ่่มเข้าในการผูกข้อมูล",
   "admin/b2b-organizations.organization-settings-select.binding.available": "การผูกข้อมูลที่มี",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "การผูกข้อมูลที่เลือก",

--- a/messages/th.json
+++ b/messages/th.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "อัปเดตการตั้งค่าเรียบร้อยแล้ว",
   "admin/b2b-organizations.organization-settings-autoApprove": "อนุมัติองค์กรใหม่โดยอัตโนมัติ",
   "admin/b2b-organizations.organization-settings-clearCart": "เคลียร์ล้อเข็นเมื่อเปลี่ยนบริษัทหรือเข้าสู่ระบบ",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "การปลอมตัวเต็มรูปแบบ",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "เพิ่่มเข้าในการผูกข้อมูล",
   "admin/b2b-organizations.organization-settings-select.binding.available": "การผูกข้อมูลที่มี",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "การผูกข้อมูลที่เลือก",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -208,6 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Налаштування оновлено",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматично підтверджувати нові організації",
   "admin/b2b-organizations.organization-settings-clearCart": "Очищати кошик при перемиканні компанії або вході в систему",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Повна імперсоналізація",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Додати до прив’язок",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Доступні прив’язки",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Вибрані прив’язки",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -208,7 +208,7 @@
   "admin/b2b-organizations.organization-settings-admin.toast.update-success": "Налаштування оновлено",
   "admin/b2b-organizations.organization-settings-autoApprove": "Автоматично підтверджувати нові організації",
   "admin/b2b-organizations.organization-settings-clearCart": "Очищати кошик при перемиканні компанії або вході в систему",
-  "admin/b2b-organizations.organization-settings-fullImpersonation": "Повна імперсоналізація",
+  "admin/b2b-organizations.organization-settings-fullImpersonation": "Дозволити вибір організації та центру витрат під час імітації",
   "admin/b2b-organizations.organization-settings-select.add-to-binding": "Додати до прив’язок",
   "admin/b2b-organizations.organization-settings-select.binding.available": "Доступні прив’язки",
   "admin/b2b-organizations.organization-settings-select.binding.selected": "Вибрані прив’язки",

--- a/react/admin/OrganizationSettings.tsx
+++ b/react/admin/OrganizationSettings.tsx
@@ -54,6 +54,7 @@ const OrganizationSettings: FunctionComponent = () => {
     uiSettings: {
       clearCart: false,
       showModal: false,
+      fullImpersonation: false,
     },
   })
 
@@ -129,6 +130,7 @@ const OrganizationSettings: FunctionComponent = () => {
       uiSettings: {
         clearCart: getB2BSettings?.uiSettings?.clearCart,
         showModal: getB2BSettings?.uiSettings?.showModal,
+        fullImpersonation: getB2BSettings?.uiSettings?.fullImpersonation,
       },
     })
   }, [dataSettings])
@@ -319,7 +321,7 @@ const OrganizationSettings: FunctionComponent = () => {
               label={formatMessage(messages.showModal)}
             />
           </div>
-          <div className="mb6">
+          <div className="mb4">
             <Checkbox
               checked={settings.uiSettings.clearCart}
               id="clearCart"
@@ -334,6 +336,23 @@ const OrganizationSettings: FunctionComponent = () => {
                 })
               }}
               label={formatMessage(messages.clearCart)}
+            />
+          </div>
+          <div className="mb6">
+            <Checkbox
+              checked={settings.uiSettings.fullImpersonation}
+              id="fullImpersonation"
+              name="fullImpersonation"
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  uiSettings: {
+                    ...settings.uiSettings,
+                    fullImpersonation: !settings.uiSettings.fullImpersonation,
+                  },
+                })
+              }}
+              label={formatMessage(messages.fullImpersonation)}
             />
           </div>
           <div className="flex br3 pa6 b--muted-4 ba">

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -462,6 +462,9 @@ export const organizationSettingsMessages = defineMessages({
   clearCart: {
     id: `${adminPrefix}organization-settings-clearCart`,
   },
+  fullImpersonation: {
+    id: `${adminPrefix}organization-settings-fullImpersonation`,
+  },
 })
 
 export const organizationCustomFieldsMessages = defineMessages({

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -326,7 +326,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
       return
     }
 
-    const uiSettings = userWidgetData?.getB2BSettings?.uiSettings
+    const uiSettings = userWidgetData?.getB2BSettings
 
     if (uiSettings?.showModal) {
       const totalCompanies = userWidgetData?.getOrganizationsByEmail?.length
@@ -633,12 +633,15 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
             <div
               className={`${handles.userWidgetItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
             >
-              {(!userWidgetData?.checkImpersonation?.email && showDropdown && (
-                <AutocompleteInput
-                  input={organizationAutoCompleteInput}
-                  options={autoCompleteOrganizationOptions}
-                />
-              )) || (
+              {((!userWidgetData?.checkImpersonation?.email ||
+                userWidgetData?.getB2BSettings?.uiSettings
+                  ?.fullImpersonation === true) &&
+                showDropdown && (
+                  <AutocompleteInput
+                    input={organizationAutoCompleteInput}
+                    options={autoCompleteOrganizationOptions}
+                  />
+                )) || (
                 <Fragment>
                   {`${formatMessage(messages.organization)} ${
                     userWidgetData?.getOrganizationByIdStorefront?.name
@@ -652,12 +655,15 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
             <div
               className={`${handles.userWidgetItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
             >
-              {(!userWidgetData?.checkImpersonation?.email && showDropdown && (
-                <AutocompleteInput
-                  input={costCenterAutoCompleteInput}
-                  options={autoCompleteCostCentersOptions}
-                />
-              )) || (
+              {((!userWidgetData?.checkImpersonation?.email ||
+                userWidgetData?.getB2BSettings?.uiSettings
+                  ?.fullImpersonation === true) &&
+                showDropdown && (
+                  <AutocompleteInput
+                    input={costCenterAutoCompleteInput}
+                    options={autoCompleteCostCentersOptions}
+                  />
+                )) || (
                 <Fragment>
                   {`${formatMessage(messages.costCenter)} ${
                     userWidgetData?.getCostCenterByIdStorefront?.name
@@ -665,31 +671,34 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
                 </Fragment>
               )}
             </div>
-            {!userWidgetData?.checkImpersonation?.email && showDropdown && (
-              <div
-                className={`${handles.userWidgetItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
-              >
-                <Button
-                  variation="primary"
-                  size="small"
-                  disabled={
-                    organizationsState.currentCostCenter ===
-                    userWidgetData?.getCostCenterByIdStorefront?.id
-                  }
-                  isLoading={loadingState}
-                  onClick={() => handleSetCurrentOrganization()}
+            {(!userWidgetData?.checkImpersonation?.email ||
+              userWidgetData?.getB2BSettings?.uiSettings?.fullImpersonation ===
+                true) &&
+              showDropdown && (
+                <div
+                  className={`${handles.userWidgetItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
                 >
-                  {formatMessage(messages.setCurrentOrganization)}
-                </Button>
-                {errorOrganization && (
-                  <div
-                    className={`${handles.userWidgetOrganizationError} error`}
+                  <Button
+                    variation="primary"
+                    size="small"
+                    disabled={
+                      organizationsState.currentCostCenter ===
+                      userWidgetData?.getCostCenterByIdStorefront?.id
+                    }
+                    isLoading={loadingState}
+                    onClick={() => handleSetCurrentOrganization()}
                   >
-                    <FormattedMessage id="store/b2b-organizations.set-organization-error" />
-                  </div>
-                )}
-              </div>
-            )}
+                    {formatMessage(messages.setCurrentOrganization)}
+                  </Button>
+                  {errorOrganization && (
+                    <div
+                      className={`${handles.userWidgetOrganizationError} error`}
+                    >
+                      <FormattedMessage id="store/b2b-organizations.set-organization-error" />
+                    </div>
+                  )}
+                </div>
+              )}
             <div
               className={`${handles.userWidgetItem} pa3 br2 bg-base--inverted hover-bg-base--inverted active-bg-base--inverted c-on-base--inverted hover-c-on-base--inverted active-c-on-base--inverted dib mr3`}
             >

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -326,7 +326,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
       return
     }
 
-    const uiSettings = userWidgetData?.getB2BSettings
+    const uiSettings = userWidgetData?.getB2BSettings?.uiSettings
 
     if (uiSettings?.showModal) {
       const totalCompanies = userWidgetData?.getOrganizationsByEmail?.length

--- a/react/graphql/getB2BSettings.graphql
+++ b/react/graphql/getB2BSettings.graphql
@@ -11,6 +11,7 @@ query GetB2BSettings {
     uiSettings {
       showModal
       clearCart
+      fullImpersonation
     }
     organizationCustomFields {
       name

--- a/react/graphql/userWidgetQuery.graphql
+++ b/react/graphql/userWidgetQuery.graphql
@@ -69,6 +69,7 @@ query userWidgetQuery($orgId: ID) {
   getB2BSettings @context(provider: "vtex.b2b-organizations-graphql") {
     uiSettings {
       showModal
+      fullImpersonation
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Our client needs to allow Customer support to impersonate a user and be able to switch between the user's Organization.

#### How to test it?
- Head over to [https://wender--kevinyeebiz.myvtex.com/](https://wender--kevinyeebiz.myvtex.com/)
- Add to your admin user access to Call Center Operator
- Now, back to the Home Page, impersonate the user `kevinyee13+salesrepa@gmail.com` (that belongs to more than one organization)
- After reloading, click My Organization; initially, you won't be able to switch to a different Organization
- Now head over to the Organization Admin, Settings tab, Enable and Save "Full Impersonation"
- Head back to the home page and open the My Organization dropdown
- You should now be able to switch

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:
Impersonating
<img width="658" alt="image" src="https://github.com/user-attachments/assets/2864417d-70cf-4606-9e9e-ee0ab864f70a">

My Organization, without Full Impersonation
<img width="522" alt="image" src="https://github.com/user-attachments/assets/a93f0e8e-8106-40ac-a0d4-21c1a7299e23">

Organization Settings
<img width="565" alt="image" src="https://github.com/user-attachments/assets/3286892f-fe0b-4e93-81bf-6700c145b125">

After the change
<img width="552" alt="image" src="https://github.com/user-attachments/assets/ea6af553-e311-4be9-89a6-5f312d7efe20">

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

[https://github.com/vtex-apps/b2b-organizations-graphql/pull/180](https://github.com/vtex-apps/b2b-organizations-graphql/pull/180)
<!--- Optional -->
