### PR TITLE
feat: add warning topbar when inactive organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add topbar and allow customization of content and colors by the merchant via storeframework.
 
 ## [1.37.3] - 2024-11-14
 ### Fixed

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "حدد مركز التكلفة",
   "admin/b2b-organizations.user-details.placeholder-role": "حدد دور",
   "admin/b2b-organizations.user-details.role": "الدور",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "البحث عن منظمة",
   "store/b2b-organizations.autocomplete-searching.cost-center": "مركز تكلفة البحث",
   "store/b2b-organizations.back": "عودة",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "الحالة المنظمة:",
   "store/b2b-organizations.user-widget.status.active": "نشطة",
   "store/b2b-organizations.user-widget.status.inactive": "غير مفعّلة",
-  "store/b2b-organizations.user-widget.status.on-hold": "قيد الانتظار"
+  "store/b2b-organizations.user-widget.status.on-hold": "قيد الانتظار",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now. Please contact us for more information."
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Избор на разходен център",
   "admin/b2b-organizations.user-details.placeholder-role": "Избор на роля",
   "admin/b2b-organizations.user-details.role": "Роля",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Търсене на организация",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Търсене на разходен център",
   "store/b2b-organizations.back": "Назад",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Статус на организацията:",
   "store/b2b-organizations.user-widget.status.active": "Активен",
   "store/b2b-organizations.user-widget.status.inactive": "Неактивен",
-  "store/b2b-organizations.user-widget.status.on-hold": "В изчакване"
+  "store/b2b-organizations.user-widget.status.on-hold": "В изчакване",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Seleccioneu un centre de costs",
   "admin/b2b-organizations.user-details.placeholder-role": "Seleccioneu un rol",
   "admin/b2b-organizations.user-details.role": "Funció",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Cerca una organització",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Cerca un centre de costs",
   "store/b2b-organizations.back": "Enrera",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Estat de l'organització:",
   "store/b2b-organizations.user-widget.status.active": "Actiu",
   "store/b2b-organizations.user-widget.status.inactive": "Inactiu",
-  "store/b2b-organizations.user-widget.status.on-hold": "En espera"
+  "store/b2b-organizations.user-widget.status.on-hold": "En espera",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "admin/b2b-organizations.user-details.placeholder-costCenter",
   "admin/b2b-organizations.user-details.placeholder-role": "admin/b2b-organizations.user-details.placeholder-role",
   "admin/b2b-organizations.user-details.role": "admin/b2b-organizations.user-details.role",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "store/b2b-organizations.warning-topbar-inative-org.form.title",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "store/b2b-organizations.warning-topbar-inative-org.form.help-text",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "store/b2b-organizations.warning-topbar-inative-org.form.color-picker-label",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "store/b2b-organizations.warning-topbar-inative-org.form.textarea-label",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "store/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text",
   "store/b2b-organizations.autocomplete-searching": "store/b2b-organizations.autocomplete-searching",
   "store/b2b-organizations.autocomplete-searching.cost-center": "store/b2b-organizations.autocomplete-searching.cost-center",
   "store/b2b-organizations.back": "store/b2b-organizations.back",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "store/b2b-organizations.user-widget.status",
   "store/b2b-organizations.user-widget.status.active": "store/b2b-organizations.user-widget.status.active",
   "store/b2b-organizations.user-widget.status.inactive": "store/b2b-organizations.user-widget.status.inactive",
-  "store/b2b-organizations.user-widget.status.on-hold": "store/b2b-organizations.user-widget.status.on-hold"
+  "store/b2b-organizations.user-widget.status.on-hold": "store/b2b-organizations.user-widget.status.on-hold",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "store/b2b-organizations.warning-topbar-inative-org.message"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Vyberte nákladové středisko",
   "admin/b2b-organizations.user-details.placeholder-role": "Vyberte roli",
   "admin/b2b-organizations.user-details.role": "Role",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Hledat organizaci",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Vyhledat nákladové středisko",
   "store/b2b-organizations.back": "Zpět",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Stav organizace:",
   "store/b2b-organizations.user-widget.status.active": "Aktivní",
   "store/b2b-organizations.user-widget.status.inactive": "Neaktivní",
-  "store/b2b-organizations.user-widget.status.on-hold": "Pozastaveno"
+  "store/b2b-organizations.user-widget.status.on-hold": "Pozastaveno",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Vælg et omkostningscenter",
   "admin/b2b-organizations.user-details.placeholder-role": "Vælg en rolle",
   "admin/b2b-organizations.user-details.role": "Rolle",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Søg organisation",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Søg omkostningscentre",
   "store/b2b-organizations.back": "Tilbage",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisations status:",
   "store/b2b-organizations.user-widget.status.active": "Aktiv",
   "store/b2b-organizations.user-widget.status.inactive": "Inaktiv",
-  "store/b2b-organizations.user-widget.status.on-hold": "Afventer"
+  "store/b2b-organizations.user-widget.status.on-hold": "Afventer",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Wählen Sie eine Kostenstelle",
   "admin/b2b-organizations.user-details.placeholder-role": "Eine Rolle auswählen",
   "admin/b2b-organizations.user-details.role": "Funktion",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Organisation suchen",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Kostenstelle suchen",
   "store/b2b-organizations.back": "Zurück",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisationsstatus:",
   "store/b2b-organizations.user-widget.status.active": "Aktiv",
   "store/b2b-organizations.user-widget.status.inactive": "Inaktiv",
-  "store/b2b-organizations.user-widget.status.on-hold": "In der Warteschleife"
+  "store/b2b-organizations.user-widget.status.on-hold": "In der Warteschleife",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Επιλογή κέντρου κόστους",
   "admin/b2b-organizations.user-details.placeholder-role": "Επιλογή ρόλου",
   "admin/b2b-organizations.user-details.role": "Ρόλος",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Αναζήτηση οργανισμού",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Αναζήτηση κέντρου κόστους",
   "store/b2b-organizations.back": "Πίσω",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Κατάσταση οργανισμού:",
   "store/b2b-organizations.user-widget.status.active": "Ενεργό",
   "store/b2b-organizations.user-widget.status.inactive": "Ανενεργό",
-  "store/b2b-organizations.user-widget.status.on-hold": "Σε αναμονή"
+  "store/b2b-organizations.user-widget.status.on-hold": "Σε αναμονή",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Select a cost center",
   "admin/b2b-organizations.user-details.placeholder-role": "Select a role",
   "admin/b2b-organizations.user-details.role": "Role",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Search organization",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Search cost center",
   "store/b2b-organizations.back": "Back",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organization Status:",
   "store/b2b-organizations.user-widget.status.active": "Active",
   "store/b2b-organizations.user-widget.status.inactive": "Inactive",
-  "store/b2b-organizations.user-widget.status.on-hold": "On Hold"
+  "store/b2b-organizations.user-widget.status.on-hold": "On Hold",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Selecciona un centro de costos",
   "admin/b2b-organizations.user-details.placeholder-role": "Selecciona un rol",
   "admin/b2b-organizations.user-details.role": "Rol",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Buscar organización",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Buscar centro de costos",
   "store/b2b-organizations.back": "Atrás",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Status de la organización:",
   "store/b2b-organizations.user-widget.status.active": "Activa",
   "store/b2b-organizations.user-widget.status.inactive": "Inactiva",
-  "store/b2b-organizations.user-widget.status.on-hold": "Suspendida"
+  "store/b2b-organizations.user-widget.status.on-hold": "Suspendida",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Valitse kustannuspaikka",
   "admin/b2b-organizations.user-details.placeholder-role": "Valitse tehtävä",
   "admin/b2b-organizations.user-details.role": "Rooli",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Hae organisaatiota",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Hae kustannuspaikkaa",
   "store/b2b-organizations.back": "Takaisin",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisaation tila:",
   "store/b2b-organizations.user-widget.status.active": "Aktiivinen",
   "store/b2b-organizations.user-widget.status.inactive": "Epäaktiivinen",
-  "store/b2b-organizations.user-widget.status.on-hold": "Pidossa"
+  "store/b2b-organizations.user-widget.status.on-hold": "Pidossa",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Sélectionnez un centre de coûts",
   "admin/b2b-organizations.user-details.placeholder-role": "Sélectionner un rôle",
   "admin/b2b-organizations.user-details.role": "Rôle",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Rechercher une organisation",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Rechercher un centre de coûts",
   "store/b2b-organizations.back": "Retour",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Statut de l’organisation :",
   "store/b2b-organizations.user-widget.status.active": "Actif",
   "store/b2b-organizations.user-widget.status.inactive": "Inactif",
-  "store/b2b-organizations.user-widget.status.on-hold": "En attente"
+  "store/b2b-organizations.user-widget.status.on-hold": "En attente",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Pilih pusat biaya",
   "admin/b2b-organizations.user-details.placeholder-role": "Pilih peran",
   "admin/b2b-organizations.user-details.role": "Peran",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Cari organisasi",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Pusat biaya header",
   "store/b2b-organizations.back": "Kembali",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Status Organisasi:",
   "store/b2b-organizations.user-widget.status.active": "Aktif",
   "store/b2b-organizations.user-widget.status.inactive": "Tidak aktif",
-  "store/b2b-organizations.user-widget.status.on-hold": "Ditahan"
+  "store/b2b-organizations.user-widget.status.on-hold": "Ditahan",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Seleziona un centro di costo",
   "admin/b2b-organizations.user-details.placeholder-role": "Seleziona un ruolo",
   "admin/b2b-organizations.user-details.role": "Ruolo",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Cerca organizzazione",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Cerca centro di costo",
   "store/b2b-organizations.back": "Indietro",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Stato organizzazione:",
   "store/b2b-organizations.user-widget.status.active": "Attivo",
   "store/b2b-organizations.user-widget.status.inactive": "Inattivo",
-  "store/b2b-organizations.user-widget.status.on-hold": "In sospeso"
+  "store/b2b-organizations.user-widget.status.on-hold": "In sospeso",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "コストセンターを選択する",
   "admin/b2b-organizations.user-details.placeholder-role": "役割を選択する",
   "admin/b2b-organizations.user-details.role": "役割",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "組織を検索する",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Search cost center",
   "store/b2b-organizations.back": "戻る",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "組織のステータス:",
   "store/b2b-organizations.user-widget.status.active": "アクティブ",
   "store/b2b-organizations.user-widget.status.inactive": "非アクティブ",
-  "store/b2b-organizations.user-widget.status.on-hold": "保留中"
+  "store/b2b-organizations.user-widget.status.on-hold": "保留中",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "비용 센터 선택",
   "admin/b2b-organizations.user-details.placeholder-role": "역할 선택",
   "admin/b2b-organizations.user-details.role": "역할",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "조직 검색",
   "store/b2b-organizations.autocomplete-searching.cost-center": "비용 센터 검색",
   "store/b2b-organizations.back": "뒤로 가기",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "조직 상태:",
   "store/b2b-organizations.user-widget.status.active": "활성",
   "store/b2b-organizations.user-widget.status.inactive": "비활성",
-  "store/b2b-organizations.user-widget.status.on-hold": "보류 중"
+  "store/b2b-organizations.user-widget.status.on-hold": "보류 중",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Selecteer een kostencentrum",
   "admin/b2b-organizations.user-details.placeholder-role": "Selecteer een rol",
   "admin/b2b-organizations.user-details.role": "Rol",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Organisatie zoeken",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Kostencentrum zoeken",
   "store/b2b-organizations.back": "Terug",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisatie status:",
   "store/b2b-organizations.user-widget.status.active": "Actief",
   "store/b2b-organizations.user-widget.status.inactive": "Inactief",
-  "store/b2b-organizations.user-widget.status.on-hold": "In de wacht"
+  "store/b2b-organizations.user-widget.status.on-hold": "In de wacht",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Velg kostnadssenter",
   "admin/b2b-organizations.user-details.placeholder-role": "Velg en rolle",
   "admin/b2b-organizations.user-details.role": "Rolle",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Søk etter organisasjon",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Søk i kostnadssted",
   "store/b2b-organizations.back": "Tilbake",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisasjonsstatus:",
   "store/b2b-organizations.user-widget.status.active": "Aktiv",
   "store/b2b-organizations.user-widget.status.inactive": "Inaktiv",
-  "store/b2b-organizations.user-widget.status.on-hold": "På vent"
+  "store/b2b-organizations.user-widget.status.on-hold": "På vent",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Wybierz centrum kosztów",
   "admin/b2b-organizations.user-details.placeholder-role": "Wybierz rolę",
   "admin/b2b-organizations.user-details.role": "Rola",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Szukaj organizacji",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Wyszukaj centrum kosztów",
   "store/b2b-organizations.back": "Wróć",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Status organizacji:",
   "store/b2b-organizations.user-widget.status.active": "Aktywny",
   "store/b2b-organizations.user-widget.status.inactive": "Nieaktywny",
-  "store/b2b-organizations.user-widget.status.on-hold": "Wstrzymanie"
+  "store/b2b-organizations.user-widget.status.on-hold": "Wstrzymanie",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Selecione um centro de custo",
   "admin/b2b-organizations.user-details.placeholder-role": "Selecione um perfil de acesso",
   "admin/b2b-organizations.user-details.role": "Perfil de acesso",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Personalização da barra superior",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Personalize a mensagem e a cor das notificações da barra superior que são exibidas quando a organização está desabilitada",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Cor da barra superior",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Mensagem",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "Caso não seja inserido nenhuma mensagem, uma mensagem padrão será exibida",
   "store/b2b-organizations.autocomplete-searching": "Buscar organização",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Buscar centro de custo",
   "store/b2b-organizations.back": "Voltar",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Situação da organização:",
   "store/b2b-organizations.user-widget.status.active": "Ativa",
   "store/b2b-organizations.user-widget.status.inactive": "Inativa",
-  "store/b2b-organizations.user-widget.status.on-hold": "Em espera"
+  "store/b2b-organizations.user-widget.status.on-hold": "Em espera",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "A conta da sua organização está pausada e você não pode concluir compras agora. Entre em contato conosco para obter mais informações."
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Selectează un centru de cost",
   "admin/b2b-organizations.user-details.placeholder-role": "Selectează un rol",
   "admin/b2b-organizations.user-details.role": "Rol",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Caută organizație",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Caută centru de cost",
   "store/b2b-organizations.back": "Înapoi",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Stare organizație:",
   "store/b2b-organizations.user-widget.status.active": "Activ",
   "store/b2b-organizations.user-widget.status.inactive": "Inactiv",
-  "store/b2b-organizations.user-widget.status.on-hold": "În așteptare"
+  "store/b2b-organizations.user-widget.status.on-hold": "În așteptare",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Выбрать финансовый центр",
   "admin/b2b-organizations.user-details.placeholder-role": "Выбрать роль",
   "admin/b2b-organizations.user-details.role": "Роль",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Поиск организаций",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Поиск финансового центра",
   "store/b2b-organizations.back": "Назад",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Статус организации:",
   "store/b2b-organizations.user-widget.status.active": "Активен",
   "store/b2b-organizations.user-widget.status.inactive": "Неактивен",
-  "store/b2b-organizations.user-widget.status.on-hold": "В ожидании"
+  "store/b2b-organizations.user-widget.status.on-hold": "В ожидании",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Vyberte nákladové stredisko",
   "admin/b2b-organizations.user-details.placeholder-role": "Vyberte rolu",
   "admin/b2b-organizations.user-details.role": "Rola",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Vyhľadať organizáciu",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Vyhľadávanie nákladového strediska",
   "store/b2b-organizations.back": "Späť",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Stav organizácie:",
   "store/b2b-organizations.user-widget.status.active": "Aktívne",
   "store/b2b-organizations.user-widget.status.inactive": "Neaktívne",
-  "store/b2b-organizations.user-widget.status.on-hold": "Pozastavené"
+  "store/b2b-organizations.user-widget.status.on-hold": "Pozastavené",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Izberite stroškovno mesto",
   "admin/b2b-organizations.user-details.placeholder-role": "Izberite vlogo",
   "admin/b2b-organizations.user-details.role": "Vloga",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Išči organizacijo",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Izberite stroškovno mesto",
   "store/b2b-organizations.back": "Nazaj",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Stanje organizacije:",
   "store/b2b-organizations.user-widget.status.active": "Aktivno",
   "store/b2b-organizations.user-widget.status.inactive": "Neaktivno",
-  "store/b2b-organizations.user-widget.status.on-hold": "Na čakanju"
+  "store/b2b-organizations.user-widget.status.on-hold": "Na čakanju",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Välj ett kostnadsställe",
   "admin/b2b-organizations.user-details.placeholder-role": "Välj en roll",
   "admin/b2b-organizations.user-details.role": "Roll",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Sök i organisation",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Sök i kostnadsställe",
   "store/b2b-organizations.back": "Återgå",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Organisation Status:",
   "store/b2b-organizations.user-widget.status.active": "Aktiv",
   "store/b2b-organizations.user-widget.status.inactive": "Inaktiv",
-  "store/b2b-organizations.user-widget.status.on-hold": "På is"
+  "store/b2b-organizations.user-widget.status.on-hold": "På is",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "เลือกศูนย์ต้นทุน",
   "admin/b2b-organizations.user-details.placeholder-role": "เลือกบทบาท",
   "admin/b2b-organizations.user-details.role": "บทบาท",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "ค้นหาองค์กร",
   "store/b2b-organizations.autocomplete-searching.cost-center": "ค้นหาศูนย์ต้นทุน",
   "store/b2b-organizations.back": "กลับ",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "สถานะองค์กร",
   "store/b2b-organizations.user-widget.status.active": "ใช้งานอยู่",
   "store/b2b-organizations.user-widget.status.inactive": "ไม่ได้ใช้งาน",
-  "store/b2b-organizations.user-widget.status.on-hold": "ระงับชั่วคราว"
+  "store/b2b-organizations.user-widget.status.on-hold": "ระงับชั่วคราว",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -270,6 +270,11 @@
   "admin/b2b-organizations.user-details.placeholder-costCenter": "Вибрати фінансовий центр",
   "admin/b2b-organizations.user-details.placeholder-role": "Вибрати роль",
   "admin/b2b-organizations.user-details.role": "Роль",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.title": "Topbar customization",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.help-text": "Customize the message and color of the top bar notifications that are displayed when the organization is disabled",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.color-picker-label": "Topbar color",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-label": "Message",
+  "admin/b2b-organizations.warning-topbar-inative-org.form.textarea-help-text": "If no message is entered, a default message will be displayed.",
   "store/b2b-organizations.autocomplete-searching": "Пошук організацій",
   "store/b2b-organizations.autocomplete-searching.cost-center": "Пошук фінансового центру",
   "store/b2b-organizations.back": "Назад",
@@ -411,5 +416,6 @@
   "store/b2b-organizations.user-widget.status": "Статус організації:",
   "store/b2b-organizations.user-widget.status.active": "Активний",
   "store/b2b-organizations.user-widget.status.inactive": "Неактивний",
-  "store/b2b-organizations.user-widget.status.on-hold": "Відкладено"
+  "store/b2b-organizations.user-widget.status.on-hold": "Відкладено",
+  "store/b2b-organizations.warning-topbar-inative-org.message": "Your organization's account is paused, and you cannot complete purchases now."
 }

--- a/react/StorefrontWarningTopbarInactiveOrganization.tsx
+++ b/react/StorefrontWarningTopbarInactiveOrganization.tsx
@@ -1,0 +1,3 @@
+import StorefrontWarningTopbarInactiveOrganization from './components/WarningTopbarInactiveOrganization'
+
+export default StorefrontWarningTopbarInactiveOrganization

--- a/react/admin/OrganizationSettings/TopbarCustom.tsx
+++ b/react/admin/OrganizationSettings/TopbarCustom.tsx
@@ -1,0 +1,60 @@
+import type { ChangeEvent } from 'react'
+import React from 'react'
+import { useIntl, FormattedMessage } from 'react-intl'
+import { Box, ColorPicker, Textarea } from 'vtex.styleguide'
+
+import { organizationSettingsMessages } from '../utils/messages'
+
+type Color = { hex: string }
+
+interface TopbarCustomProps {
+  colorState: {
+    color: Color
+    history: string[]
+  }
+  message: string
+  onChangeColor: (color: Color) => void
+  onChangeMessage: (text: string) => void
+}
+
+export function TopbarCustom({
+  colorState,
+  message,
+  onChangeColor,
+  onChangeMessage,
+}: TopbarCustomProps) {
+  const { formatMessage } = useIntl()
+
+  return (
+    <div className="mv4 topbar-custom">
+      <Box style={{ padding: 0 }}>
+        <h3 className="t-heading-3">
+          <FormattedMessage id="admin/b2b-organizations.warning-topbar-inative-org.form.title" />
+        </h3>
+        <p className="t-small mw9 mb5">
+          <FormattedMessage id="admin/b2b-organizations.warning-topbar-inative-org.form.help-text" />
+        </p>
+        <ColorPicker
+          label={formatMessage(
+            organizationSettingsMessages.formColorPickerLabel
+          )}
+          color={colorState.color}
+          colorHistory={colorState.history}
+          onChange={onChangeColor}
+        />
+        <Textarea
+          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+            onChangeMessage(event.target.value)
+          }
+          value={message}
+          label={formatMessage(organizationSettingsMessages.formTextareaLabel)}
+          name="message"
+          size="small"
+          helpText={formatMessage(
+            organizationSettingsMessages.formTextareaHelpText
+          )}
+        />
+      </Box>
+    </div>
+  )
+}

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -497,6 +497,15 @@ export const organizationSettingsMessages = defineMessages({
   },
   fullImpersonation: {
     id: `${adminPrefix}organization-settings-fullImpersonation`,
+    formColorPickerLabel: {
+      id: `${adminPrefix}warning-topbar-inative-org.form.color-picker-label`,
+    },
+    formTextareaLabel: {
+      id: `${adminPrefix}warning-topbar-inative-org.form.textarea-label`,
+    },
+    formTextareaHelpText: {
+      id: `${adminPrefix}warning-topbar-inative-org.form.textarea-help-text`,
+    },
   },
 })
 

--- a/react/components/WarningTopbarInactiveOrganization.tsx
+++ b/react/components/WarningTopbarInactiveOrganization.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-apollo'
 import { FormattedMessage } from 'react-intl'
 
 import GET_B2B_SETTINGS from '../graphql/getB2BSettings.graphql'
+import storageFactory from '../utils/storage'
 
 function getContrastColor(hexColor: string) {
   const color = hexColor.replace('#', '')
@@ -16,12 +17,21 @@ function getContrastColor(hexColor: string) {
   return brightness > 128 ? '#000000' : '#FFFFFF'
 }
 
+const localStore = storageFactory(() => localStorage)
+const isAuthenticated =
+  JSON.parse(String(localStore.getItem('b2b-organizations_isAuthenticated'))) ??
+  false
+
 const WarningTopbarInactiveOrganization = () => {
   const { data, loading } = useQuery(GET_B2B_SETTINGS, {
     ssr: false,
   })
 
-  if (loading || data?.getB2BSettings?.uiSettings?.autoApprove) {
+  if (
+    loading ||
+    data?.getB2BSettings?.uiSettings?.autoApprove ||
+    !isAuthenticated
+  ) {
     return <></>
   }
 

--- a/react/components/WarningTopbarInactiveOrganization.tsx
+++ b/react/components/WarningTopbarInactiveOrganization.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useQuery } from 'react-apollo'
+import { FormattedMessage } from 'react-intl'
+
+import GET_B2B_SETTINGS from '../graphql/getB2BSettings.graphql'
+
+function getContrastColor(hexColor: string) {
+  const color = hexColor.replace('#', '')
+
+  const r = parseInt(color.substring(0, 2), 16)
+  const g = parseInt(color.substring(2, 4), 16)
+  const b = parseInt(color.substring(4, 6), 16)
+
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+
+  return brightness > 128 ? '#000000' : '#FFFFFF'
+}
+
+const WarningTopbarInactiveOrganization = () => {
+  const { data, loading } = useQuery(GET_B2B_SETTINGS, {
+    ssr: false,
+  })
+
+  if (loading || data?.getB2BSettings?.uiSettings?.autoApprove) {
+    return <></>
+  }
+
+  return (
+    <div
+      className="pv3"
+      style={{
+        width: '100%',
+        textAlign: 'center',
+        fontWeight: 500,
+        color: getContrastColor(
+          data?.getB2BSettings?.uiSettings?.topBar?.hexColor ?? '#656896'
+        ),
+        background:
+          data?.getB2BSettings?.uiSettings?.topBar?.hexColor ?? '#656896',
+      }}
+    >
+      {data?.getB2BSettings?.uiSettings?.topBar?.name || (
+        <FormattedMessage id="store/b2b-organizations.warning-topbar-inative-org.message" />
+      )}
+    </div>
+  )
+}
+
+export default WarningTopbarInactiveOrganization

--- a/react/graphql/getB2BSettings.graphql
+++ b/react/graphql/getB2BSettings.graphql
@@ -12,6 +12,10 @@ query GetB2BSettings {
       showModal
       clearCart
       fullImpersonation
+      topBar {
+        name
+        hexColor
+      }
     }
     organizationCustomFields {
       name

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -14,6 +14,9 @@
           "default": false
         }
       }
+    },
+    "StorefrontWarningTopbarInactiveOrganizationProps": {
+      "title": "warningTopbarInactiveOrganization"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -26,6 +26,9 @@
   "b2b-user-widget": {
     "component": "StorefrontUserWidget"
   },
+  "b2b-warning-topbar-inactive-organization": {
+    "component": "StorefrontWarningTopbarInactiveOrganization"
+  },
   "b2b-seller-wrapper": {
     "component": "SellerWrapper",
     "allowed": "*",


### PR DESCRIPTION
#### What problem is this solving?
Allow customization of content and colors by the merchant via storeframework. Add information right after login with customizable message via storeframework

#### How to test it?

Run the b2b-organizations and this repo - Run the [https://github.com/vtex-apps/b2b-organizations-graphql/pull/182](https://github.com/vtex-apps/b2b-organizations-graphql/pull/182) - Run the b2b-theme

1. Access [https://josmarjr--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/#/settings](https://josmarjr--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/#/settings)
2. Uncheck "Aprovar automaticamente novas organizações"
3. Change the color at color picker or/and insert a new message to show at topbar
4. Save the changes
5. Access the store and do the login with your account

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[[Workspace](https://josmarjr--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/#/settings)](Link goes here!)

#### Screenshots or example usage:
<img width="1440" alt="Screenshot 2024-10-17 at 17 28 54" src="https://github.com/user-attachments/assets/dae51f3a-4bb3-4492-b5f7-5335778771f5">
<img width="1440" alt="Screenshot 2024-10-17 at 17 27 59" src="https://github.com/user-attachments/assets/dedafa5d-b9f7-44b1-8c90-4f75bb9e0b00">


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
