### PR TITLE
Fix/change get organizations by email endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Change `getOrganizationsByEmail` to `getActiveOrganizationsByEmail` to only allow listings from active organizations
 
 ## [1.38.0] - 2024-12-09
 ### Added

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -284,7 +284,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
         ...organizationsState,
         organizationInput: text,
         organizationOptions:
-          userWidgetData?.getOrganizationsByEmail
+          userWidgetData?.getActiveOrganizationsByEmail
             ?.filter((organization: any) => {
               return organization?.organizationName
                 ?.toLowerCase()
@@ -322,14 +322,16 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
   }
 
   useEffect(() => {
-    if (!userWidgetData?.getOrganizationsByEmail) {
+    if (!userWidgetData?.getActiveOrganizationsByEmail) {
       return
     }
 
     const uiSettings = userWidgetData?.getB2BSettings?.uiSettings
 
     if (uiSettings?.showModal) {
-      const totalCompanies = userWidgetData?.getOrganizationsByEmail?.length
+      const totalCompanies =
+        userWidgetData?.getActiveOrganizationsByEmail?.length
+
       const storageShowModal = sessionStorage.getItem(
         SESSION_STORAGE_SHOW_MODAL
       )
@@ -348,16 +350,16 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
       ...organizationsState,
       costCenterInput: userWidgetData?.getCostCenterByIdStorefront?.name,
       organizationInput: userWidgetData?.getOrganizationByIdStorefront?.name,
-      organizationOptions: userWidgetData?.getOrganizationsByEmail
+      organizationOptions: userWidgetData?.getActiveOrganizationsByEmail
         .slice(0, 15)
         .map((organization: { orgId: string; organizationName: string }) => ({
           value: organization.orgId,
           label: organization.organizationName,
         })),
-      currentRoleName: userWidgetData?.getOrganizationsByEmail?.find(
+      currentRoleName: userWidgetData?.getActiveOrganizationsByEmail?.find(
         (organizations: any) => organizations.costId === currentCostCenter
       )?.role?.name,
-      costCenterOptions: userWidgetData?.getOrganizationsByEmail
+      costCenterOptions: userWidgetData?.getActiveOrganizationsByEmail
         .filter(
           (organization: { orgId: string }) =>
             organization.orgId === currentOrganization
@@ -368,10 +370,10 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
         })),
       currentOrganization,
       currentCostCenter,
-      dataList: userWidgetData?.getOrganizationsByEmail?.sort(
+      dataList: userWidgetData?.getActiveOrganizationsByEmail?.sort(
         sortOrganizations
       ),
-      totalDataList: userWidgetData?.getOrganizationsByEmail?.length,
+      totalDataList: userWidgetData?.getActiveOrganizationsByEmail?.length,
       currentOrganizationStatus:
         userWidgetData?.getOrganizationByIdStorefront?.status,
     })
@@ -413,7 +415,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
         ...organizationsState,
         costCenterInput: '',
         currentOrganization: itemSelected.value,
-        costCenterOptions: userWidgetData?.getOrganizationsByEmail
+        costCenterOptions: userWidgetData?.getActiveOrganizationsByEmail
           .filter(
             (organization: { orgId: string }) =>
               organization.orgId === itemSelected.value
@@ -465,11 +467,13 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
 
     setSearchTerm(e.target.value)
 
-    dataList = userWidgetData?.getOrganizationsByEmail?.sort(sortOrganizations)
+    dataList = userWidgetData?.getActiveOrganizationsByEmail?.sort(
+      sortOrganizations
+    )
 
     if (value.trim() !== '') {
       dataList =
-        userWidgetData?.getOrganizationsByEmail
+        userWidgetData?.getActiveOrganizationsByEmail
           ?.filter((organization: any) => {
             return (
               organization.organizationName
@@ -615,7 +619,7 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
                 }`}
               </div>
               <div className="ml-auto">
-                {userWidgetData?.getOrganizationsByEmail?.length > 1 && (
+                {userWidgetData?.getActiveOrganizationsByEmail?.length > 1 && (
                   <Button variant="primary" onClick={() => setShowModal(true)}>
                     {formatMessage(messages.changeOrganization)}
                   </Button>

--- a/react/graphql/userWidgetQuery.graphql
+++ b/react/graphql/userWidgetQuery.graphql
@@ -1,5 +1,6 @@
 query userWidgetQuery($orgId: ID) {
-  getOrganizationsByEmail @context(provider: "vtex.b2b-organizations-graphql") {
+  getActiveOrganizationsByEmail
+    @context(provider: "vtex.b2b-organizations-graphql") {
     id
     costCenterName
     costId


### PR DESCRIPTION
#### What problem is this solving?
Before, autocomplete and the organizations modal listed active and inactive organizations. Now, list only active organizations

<!--- What is the motivation and context for this change? -->
List only active organizations

#### How to test it?
1. Run the project 
2. Make a login and search a organization on Autocomplete

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[[Workspace](https://josmarsoares--b2bstore005.myvtex.com/)](https://josmarsoares--b2bstore005.myvtex.com/)

#### Screenshots or example usage:
<img width="1111" alt="Screenshot 2024-10-30 at 15 09 24" src="https://github.com/user-attachments/assets/ad65f4b3-e7f4-46ad-a8b7-a0d7fb43a94f">


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
