### PR TITLE
[TICKET #1162917] Fix render when admin customer is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix render on organization requests when admin customer is missing from organization
 
 ## [1.39.9] - 2025-01-07
 ### Fixed

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "طلب المنظمة",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "تم إنشاء المنظمة بنجاح",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "فشل التحديث. راجع وحدة التحكم للحصول على التفاصيل.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "تم تحديث طلب المنظمة بنجاح",
   "admin/b2b-organizations.organization-request-details.tradeName": "الإسم التجاري",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "قم بتوفير الاسم التجاري للمنظمة، والذي سيتم تطبيقه في الدفع، إن وجد. (اختياري)",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Заявка за организация",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Организацията е създадена успешно",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Неуспешно актуализиране. Вижте конзолата за подробности.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Заявката за организация е актуализирана успешно",
   "admin/b2b-organizations.organization-request-details.tradeName": "Търговско наименование",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Предоставете търговското наименование на организацията, което ще бъде приложено при финализирането, ако има такова. (По желание)",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Sol·licitud de l'organització",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "S'ha creat correctament l'organització",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "S'ha produït un error en fer l'actualització. Per obtenir-ne més informació, consulteu la consola.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "S'ha actualitzat correctament la sol·licitud de l'organització",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nom comercial",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Proporcioneu el nom comercial de l'organització, que s'aplicarà en el procés de pagament, si n'hi ha cap. (Opcional)",

--- a/messages/context.json
+++ b/messages/context.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "admin/b2b-organizations.organization-request-details.title",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "admin/b2b-organizations.organization-request-details.toast.created-success",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "admin/b2b-organizations.organization-request-details.toast.update-failure",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "admin/b2b-organizations.organization-request-details.toast.update-success",
   "admin/b2b-organizations.organization-request-details.tradeName": "admin/b2b-organizations.organization-request-details.tradeName",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "admin/b2b-organizations.organization-request-details.tradeName.helpText",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Žádost o vytvoření organizace",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizace úspěšně vytvořena",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Aktualizace selhala. Podrobnosti naleznete v konzoli.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Žádost o vytvoření organizace byla úspěšně aktualizována",
   "admin/b2b-organizations.organization-request-details.tradeName": "Obchodní název",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Uveďte obchodní název organizace, který pak bude použit u pokladny. (Nepovinné)",

--- a/messages/da.json
+++ b/messages/da.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisation forespørgsel",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisation oprettet med succes",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Opdatering mislykkedes. Se konsollen for detaljer.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisation forespørgsel opdateret med succes",
   "admin/b2b-organizations.organization-request-details.tradeName": "Handelsnavn",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Angiv organisationens firmanavn, som vil blive anvendt i kassen, hvis det er muligt. (Valgfrit)",

--- a/messages/de.json
+++ b/messages/de.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisationsanforderung",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisation erfolgreich erstellt",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Update fehlgeschlagen, siehe Konsole für Details.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisationsgruppe erfolgreich aktualisiert",
   "admin/b2b-organizations.organization-request-details.tradeName": "Trade name",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Optional geben Sie den Handelsnamen der Organisation an, der in der Kasse angewendet wird, falls vorhanden",

--- a/messages/el.json
+++ b/messages/el.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Αίτημα οργανισμού",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Ο οργανισμός δημιουργήθηκε με επιτυχία",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Η ενημέρωση απέτυχε. Βλέπε κονσόλα για λεπτομέρειες.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Το αίτημα οργανισμού ενημερώθηκε με επιτυχία",
   "admin/b2b-organizations.organization-request-details.tradeName": "Εμπορική ονομασία",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Παρέχετε το εμπορικό όνομα του οργανισμού, το οποίο θα εφαρμοστεί στην ολοκλήρωση αγοράς, αν υπάρχει. (Προαιρετικό)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organization Request",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organization created successfully",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Update failed. See console for details.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organization request updated successfully",
   "admin/b2b-organizations.organization-request-details.tradeName": "Trade name",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Provide the organization's trade name, which will be applied in checkout, if any. (Optional)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Solicitud de organización",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organización creada con éxito.",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "La actualización falló. Consulta la consola para ver los detalles.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "La solicitud de organización se actualizó con éxito",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nombre comercial",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Proporciona el nombre comercial de la organización que se aplicará en el checkout, si alguno. (Opcional)",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisaation pyyntö",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisaatio luotu onnistuneesti",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Päivitys epäonnistui. Katso lisätietoja konsolista.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisaation pyyntö päivitetty onnistuneesti",
   "admin/b2b-organizations.organization-request-details.tradeName": "Kauppanimi",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Anna organisaation toiminimi, joka otetaan tarvittaessa käyttöön kassalla. (Valinnainen)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Demande d’organisation",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisation créée",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "La mise à jour a échoué. Consultez la console pour plus de détails.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "La demande d’organisation a bien été mise à jour",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nom commercial",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Indiquez le nom de la transaction de l’organisation, qui sera appliquée lors de la commande, le cas échéant. (Facultatif)",

--- a/messages/id.json
+++ b/messages/id.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Permintaan Organisasi",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Berhasil membuat organisasi",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Pembaruan gagal. Lihat konsol untuk detailnya.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Permintaan organisasi berhasil diperbarui",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nama dagang",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Masukkan nama dagang organisasi yang akan diterapkan di checkout. (Opsional)",

--- a/messages/it.json
+++ b/messages/it.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Richiesta di organizzazione",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizzazione creata correttamente",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Aggiornamento non riuscito. Visualizza la console per i dettagli.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Richiesta di organizzazione aggiornata correttamente",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nome commerciale",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Fornisci il nome commerciale dell'organizzazione. Verrà applicato nel checkout se presente. (Facoltativo)",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "組織のリクエスト",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "組織の作成が完了しました",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "更新できませんでした。詳細はコンソールを確認してください。",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "組織リクエストの更新が完了しました",
   "admin/b2b-organizations.organization-request-details.tradeName": "商号",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "チェックアウト時に適用される組織の商号があれば、入力してください。 (任意)",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "조직 요청",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "조직이 생성되었습니다.",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "업데이트 실패. 자세한 내용은 콘솔을 참조하세요.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "조직 요청이 성공적으로 업데이트되었습니다.",
   "admin/b2b-organizations.organization-request-details.tradeName": "거래명",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "체크아웃 시 적용될 조직의 상호(있는 경우)를 제공합니다. (선택사항)",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisatieverzoek",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisatie aangemaakt",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Update is mislukt. Zie de console voor meer informatie.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisatieverzoek bijgewerkt",
   "admin/b2b-organizations.organization-request-details.tradeName": "Handelsnaam",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Geef de handelsnaam van de organisatie aan, die zal worden toegepast bij het afrekenen, indien van toepassing. (optioneel)",

--- a/messages/no.json
+++ b/messages/no.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisasjonsforespørsel",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisasjonen ble opprettet",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Oppdateringen mislyktes. Se konsoll for mer informasjon.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisasjonsforespørselen ble oppdatert",
   "admin/b2b-organizations.organization-request-details.tradeName": "Handelsnavn",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Oppgi organisasjonens handelsnavn, som vil bli brukt i kassen hvis det finnes. (Valgfritt)",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Żądanie organizacji",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizacja została pomyślnie utworzona",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Aktualizacja nie powiodła się. Zobacz konsolę, aby uzyskać więcej informacji.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Żądanie organizacji zostało pomyślnie zaktualizowane",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nazwa handlowa",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Podaj nazwę handlową organizacji, która zostanie zastosowana w kasie, jeśli jest obecna. (Opcjonalnie)",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Solicitação de organização",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organização criada com sucesso",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Falha na atualização. Consulte o console para mais detalhes.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "B2B Customer Admin não está presente na organização, incapaz de aprovar",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Solicitação da organização atualizada com sucesso",
   "admin/b2b-organizations.organization-request-details.tradeName": "Nome fantasia",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Insira o nome fantasia da organização que será aplicado no checkout, se houver. (Opcional)",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Solicitare organizație",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizație creată cu succes",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Actualizarea a eșuat. Vezi consola pentru detalii.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Solicitare organizație actualizată cu succes",
   "admin/b2b-organizations.organization-request-details.tradeName": "Denumire comercială",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Furnizează denumirea comercială a organizației, care se va aplica la finalizarea comenzii, dacă e cazul. (Opțional)",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Запрос организации",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Организация создана",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Не удалось обновить. Подробная информация доступна на консоли.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Запрос организации обновлён",
   "admin/b2b-organizations.organization-request-details.tradeName": "Торговое наименование",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Укажите коммерческое название организации, которое будет указываться при оформлении заказа. (Необязательно)",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Požiadavka organizácie",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizácia bola úspešne vytvorená",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Aktualizacia bola neuspešná. Podrobnosti nájdete v konzole.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Požiadavka organizácie bola úspešne aktualizovaná",
   "admin/b2b-organizations.organization-request-details.tradeName": "Obchodné meno",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Uveďte obchodný názov organizácie, ktorý bude použitý v pokladni, ak existuje. (Voliteľné)",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Zahteva organizacije",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organizacija je bila uspešno ustvarjena",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Posodobitev ni uspela. Za podrobnosti glejte konzolo.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Zahteva organizacije je bila uspešno posodobljena",
   "admin/b2b-organizations.organization-request-details.tradeName": "Blagovna znamka",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Navedite trgovsko ime organizacije, ki bo uporabljeno na blagajni, če obstaja. (Neobvezno)",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Organisationsförfrågan",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Organisationen skapades",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Uppdateringen misslyckades. Se konsolen för detaljer.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Organisationsförfrågan har uppdaterats",
   "admin/b2b-organizations.organization-request-details.tradeName": "Handelsnamn",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Ange organisationens handelsbetckning, som kommer att tillämpas i kassan, om någon. (Valfritt)",

--- a/messages/th.json
+++ b/messages/th.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "คำขอองค์กร",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "สร้างองค์กรเรียบร้อยแล้ว",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "อัปเดตไม่สำเร็จ โปรดดูรายละเอียดในคอนโซล",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "อัปเดตคำขอองค์กรเรียบร้อยแล้ว",
   "admin/b2b-organizations.organization-request-details.tradeName": "ชื่อการค้า",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "ให้ชื่อการค้าขององค์กร หากมี จะใช้ในการเช็คเอาต์ (ไม่บังคับ)",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -180,6 +180,7 @@
   "admin/b2b-organizations.organization-request-details.title": "Запит організації",
   "admin/b2b-organizations.organization-request-details.toast.created-success": "Організацію створено успішно",
   "admin/b2b-organizations.organization-request-details.toast.update-failure": "Не вдалося оновити. Докладніша інформація доступна на консолі.",
+  "admin/b2b-organizations.organization-request-details.toast.update-failure-missing-email": "Missing B2B Customer Admin in organization, unable to approve it",
   "admin/b2b-organizations.organization-request-details.toast.update-success": "Запит організації оновлено",
   "admin/b2b-organizations.organization-request-details.tradeName": "Торговельна назва",
   "admin/b2b-organizations.organization-request-details.tradeName.helpText": "Вкажіть комерційну назву організації, яка вказуватиметься під час оформлення замовлення. (Не обов’язково)",

--- a/react/admin/OrganizationRequestDetails.tsx
+++ b/react/admin/OrganizationRequestDetails.tsx
@@ -48,6 +48,20 @@ const OrganizationRequestDetails: FunctionComponent = () => {
       notes: notesState,
     }
 
+    if (
+      !data.getOrganizationRequestById.b2bCustomerAdmin &&
+      status === 'approved'
+    ) {
+      showToast({
+        variant: 'critical',
+        message: formatMessage(messages.toastUpdateFailureNoEmail),
+      })
+
+      setLoadingState(false)
+
+      return
+    }
+
     updateOrganizationRequest({ variables })
       .then(() => {
         setLoadingState(false)
@@ -151,7 +165,7 @@ const OrganizationRequestDetails: FunctionComponent = () => {
           <FormattedMessage id="admin/b2b-organizations.organization-request-details.b2b-customer-admin" />
         </h4>
         <div className="mv3">
-          {data.getOrganizationRequestById.b2bCustomerAdmin.email}
+          {data.getOrganizationRequestById.b2bCustomerAdmin?.email}
         </div>
         <h4 className="t-heading-5 mb0 pt4">
           <FormattedMessage id="admin/b2b-organizations.organization-request-details.default-cost-center" />

--- a/react/admin/OrganizationRequestsTable.tsx
+++ b/react/admin/OrganizationRequestsTable.tsx
@@ -63,11 +63,8 @@ const OrganizationRequestsTable: FunctionComponent = () => {
       },
       b2bCustomerAdmin: {
         title: formatMessage(messages.columnAdmin),
-        cellRenderer: ({
-          rowData: {
-            b2bCustomerAdmin: { email },
-          },
-        }: CellRendererProps) => email,
+        cellRenderer: ({ rowData: { b2bCustomerAdmin } }: CellRendererProps) =>
+          b2bCustomerAdmin?.email ?? '',
       },
       status: {
         title: formatMessage(messages.columnStatus),

--- a/react/admin/utils/messages.ts
+++ b/react/admin/utils/messages.ts
@@ -366,6 +366,9 @@ export const organizationRequestMessages = defineMessages({
   toastUpdateFailure: {
     id: `${adminPrefix}organization-request-details.toast.update-failure`,
   },
+  toastUpdateFailureNoEmail: {
+    id: `${adminPrefix}organization-request-details.toast.update-failure-missing-email`,
+  },
   detailsPageTitle: {
     id: `${adminPrefix}organization-request-details.title`,
   },


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Fix render when admin customer is missing but prevent approval of organization

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

With Fix:
[Client Account](https://everton--tezool.myvtex.com/admin/b2b-organizations/organizations#/requests)

Without Fix:
[Client Account](https://tezool.myvtex.com/admin/b2b-organizations/organizations#/requests)

#### Screenshots or example usage:

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/6c6cbd24-baa8-4feb-83e5-88818d7fffb0" />
