### PR TITLE
fix: add org name and cost center normalization when getting active orgs for userWidget

### DIFF
--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -473,18 +473,18 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
 
     if (value.trim() !== '') {
       dataList =
-        userWidgetData?.getActiveOrganizationsByEmail
+        userWidgetData?.getOrganizationsByEmail
           ?.filter((organization: any) => {
+            const organizationName = organization.organizationName?.toLowerCase() || '';
+            const costCenterName = organization.costCenterName?.toLowerCase() || '';
+            const searchValue = value.toLowerCase();
+ 
             return (
-              organization.organizationName
-                .toLowerCase()
-                .includes(value.toLowerCase()) ||
-              organization.costCenterName
-                .toLowerCase()
-                .includes(value.toLowerCase())
-            )
+              organizationName.includes(searchValue) ||
+              costCenterName.includes(searchValue)
+            );
           })
-          ?.slice(0, 15) ?? []
+          ?.slice(0, 15) ?? [];
     }
 
     setOrganizationsState({

--- a/react/components/UserWidget.tsx
+++ b/react/components/UserWidget.tsx
@@ -463,17 +463,16 @@ const UserWidget: VtexFunctionComponent<UserWidgetProps> = ({
 
   const handleSearchOrganizations = (e: any) => {
     const { value }: { value: string } = e.target
-    let dataList
+    let dataList;
 
     setSearchTerm(e.target.value)
 
     dataList = userWidgetData?.getActiveOrganizationsByEmail?.sort(
       sortOrganizations
     )
-
     if (value.trim() !== '') {
       dataList =
-        userWidgetData?.getOrganizationsByEmail
+        userWidgetData?.getActiveOrganizationsByEmail
           ?.filter((organization: any) => {
             const organizationName = organization.organizationName?.toLowerCase() || '';
             const costCenterName = organization.costCenterName?.toLowerCase() || '';


### PR DESCRIPTION
#### What problem is this solving?

When there's a missing field either on organization name or cost center it raises an error

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[marcofbb workspace](https://marcofbb--cromosol.myvtex.com/)

#### Screenshots or example usage:

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/30224856-ef39-4a98-b5c6-184264ea45db" />

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjRzc2E5NzVqaGx0djZ2ZHNtc2h4cmk4Zzl5bHJtaWcxaHlwb210YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/yqtpq8rqqXBh6/giphy.gif)
