### PR TITLE
fix: search in users tab in b2b organization details

### DIFF
--- a/react/components/OrganizationUsersTable.tsx
+++ b/react/components/OrganizationUsersTable.tsx
@@ -151,10 +151,9 @@ const OrganizationUsersTable: FunctionComponent<Props> = ({
   const [impersonateUser] = useMutation(IMPERSONATE_USER)
 
   useEffect(() => {
-    if (!data?.getUsersPaginated?.data?.length) return
+    if (!data?.getUsersPaginated?.data) return
 
     const users = data.getUsersPaginated.data.sort(compareUsers)
-
     setUsersState(users)
   }, [data])
 


### PR DESCRIPTION
#### What problem is this solving?

When searching in the Users tab in B2B Organization Details with a term that has no result, nothing is filtered, and all users are shown in the result.

#### How to test it?

Search by a term in the Users tab that doesn't exist;
The results will load, but all users are shown. 

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://grigaud--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/b2013d52-8feb-11ef-b37f-b15521bf019b#/users)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
