### PR TITLE
docs: add guidance to prevent image overflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,17 @@ if we have more than one associated organization:
 
 In order to apply CSS customizations in this and other apps, follow the instructions on [Using CSS Handles for store customization](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-using-css-handles-for-store-customization).
 
+If your store adds images to pages rendered by this app, make sure they are responsive in your storefront CSS. Otherwise, they may keep their native width and overlap the page navigation. For example:
+
+```css
+img {
+  max-width: 100%;
+  height: auto;
+}
+```
+
+You can scope this rule to the page or CSS handle you are customizing.
+
 CSS handles are available for the **Organization Request Form** component and the **User Widget** component.
 
 | **CSS Handles**                   |


### PR DESCRIPTION
Adds documentation guidance to help storefront implementers avoid image overflow on pages rendered by this app.

## Changes

- adds a note in the README customization section about making images responsive
- includes a CSS example using `max-width: 100%` and `height: auto`
- recommends scoping the rule to the relevant page or CSS handle

## Why

This addresses feedback (EDU-17787) about images overflowing into the in-page navigation and gives readers the implementation guidance they need without changing the generated documentation styling itself.

