### PR TITLE
resolving user email from session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- "NEW" user button on My Organization (storefront) when session has no `adminUserEmail`.
+- "NEW" user button on My Organization (storefront): License Manager `granted` check now sends `VtexIdclientAutCookie` from the session cookie namespace (by account), so the request is authorized on the public domain.
 
 ## [3.1.9] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- "NEW" user button on My Organization (storefront) when session has no `adminUserEmail`.
+
 ## [3.1.9] - 2026-03-19
 
 ## [3.1.8] - 2026-03-12

--- a/react/hooks/useOrgPermission.ts
+++ b/react/hooks/useOrgPermission.ts
@@ -14,15 +14,27 @@ export function useOrgPermission({
 }: UseOrgPermissionParams) {
   const fullSession = useFullSession({
     variables: {
-      items: ['authentication.adminUserEmail', 'account.accountName'],
+      items: [
+        'authentication.adminUserEmail',
+        'authentication.storeUserEmail',
+        'profile.email',
+        'account.accountName',
+      ],
     },
   })
 
   const account =
     fullSession.data?.session?.namespaces?.account?.accountName?.value
 
-  const userEmail =
-    fullSession.data?.session?.namespaces?.authentication?.adminUserEmail?.value
+  const namespaces = fullSession.data?.session?.namespaces
+
+  const adminUserEmail =
+    namespaces?.authentication?.adminUserEmail?.value
+  const storeUserEmail =
+    namespaces?.authentication?.storeUserEmail?.value
+  const profileEmail = namespaces?.profile?.email?.value
+
+  const userEmail = adminUserEmail || storeUserEmail || profileEmail
 
   const { data, isLoading, isValidating, error } = useSWR<{ data: boolean }>(
     userEmail && account ? `/granted?${resourceCode}` : null,

--- a/react/hooks/useOrgPermission.ts
+++ b/react/hooks/useOrgPermission.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { useFullSession } from 'vtex.session-client'
 
@@ -9,22 +10,47 @@ interface UseOrgPermissionParams {
   resourceCode?: typeof ORGANIZATION_EDIT | typeof ORGANIZATION_VIEW
 }
 
+const VTEX_ID_CLIENT_AUT_COOKIE_KEY_PREFIX = 'VtexIdclientAutCookie'
+
+const BASE_SESSION_ITEMS = [
+  'authentication.adminUserEmail',
+  'authentication.storeUserEmail',
+  'profile.email',
+  'account.accountName',
+] as const
+
 export function useOrgPermission({
   resourceCode = ORGANIZATION_VIEW,
 }: UseOrgPermissionParams) {
+  const [accountForSessionItems, setAccountForSessionItems] = useState<
+    string | undefined
+  >()
+
+  const sessionItems = useMemo(() => {
+    if (!accountForSessionItems) {
+      return [...BASE_SESSION_ITEMS]
+    }
+
+    return [
+      ...BASE_SESSION_ITEMS,
+      `cookie.${VTEX_ID_CLIENT_AUT_COOKIE_KEY_PREFIX}_${accountForSessionItems}`,
+    ]
+  }, [accountForSessionItems])
+
   const fullSession = useFullSession({
     variables: {
-      items: [
-        'authentication.adminUserEmail',
-        'authentication.storeUserEmail',
-        'profile.email',
-        'account.accountName',
-      ],
+      items: sessionItems,
     },
   })
 
   const account =
     fullSession.data?.session?.namespaces?.account?.accountName?.value
+
+  useEffect(() => {
+    if (account && account !== accountForSessionItems) {
+      setAccountForSessionItems(account)
+    }
+  }, [account, accountForSessionItems])
 
   const namespaces = fullSession.data?.session?.namespaces
 
@@ -36,13 +62,21 @@ export function useOrgPermission({
 
   const userEmail = adminUserEmail || storeUserEmail || profileEmail
 
+  const vtexAuthCookie = account
+    ? namespaces?.cookie?.[`${VTEX_ID_CLIENT_AUT_COOKIE_KEY_PREFIX}_${account}`]
+        ?.value
+    : undefined
+
   const { data, isLoading, isValidating, error } = useSWR<{ data: boolean }>(
-    userEmail && account ? `/granted?${resourceCode}` : null,
+    userEmail && account && vtexAuthCookie
+      ? `/granted?${resourceCode}`
+      : null,
     () =>
       checkUserAdminPermission({
         account,
         userEmail,
         resourceCode,
+        authCookie: vtexAuthCookie,
       }),
     {
       dedupingInterval: 0,

--- a/react/services/orgPermissionClient.ts
+++ b/react/services/orgPermissionClient.ts
@@ -3,22 +3,36 @@ import axios from 'axios'
 import { B2B_LM_PRODUCT_CODE } from '../utils/constants'
 
 const LICENSE_MANAGER_BASE_URL = `/api/license-manager/pvt/accounts/`
+const VTEX_ID_CLIENT_AUT_COOKIE_PREFIX = 'VtexIdclientAutCookie'
 
 const orgPermissionClient = axios.create()
 
 orgPermissionClient.defaults.baseURL = LICENSE_MANAGER_BASE_URL
+orgPermissionClient.defaults.withCredentials = true
 
 interface CheckUserAdminPermissionParams {
   account: string
   userEmail: string
   resourceCode: string
+  authCookie: string
 }
 
 const checkUserAdminPermission = async ({
   account,
   userEmail,
   resourceCode,
+  authCookie,
 }: CheckUserAdminPermissionParams) => {
+  if (authCookie) {
+    orgPermissionClient.defaults.headers.common[
+      VTEX_ID_CLIENT_AUT_COOKIE_PREFIX
+    ] = authCookie
+  } else {
+    delete orgPermissionClient.defaults.headers.common[
+      VTEX_ID_CLIENT_AUT_COOKIE_PREFIX
+    ]
+  }
+
   const checkOrgPermission = await orgPermissionClient.get(
     `${account}/products/${B2B_LM_PRODUCT_CODE}/logins/${userEmail}/resources/${resourceCode}/granted`
   )


### PR DESCRIPTION
## Summary

Fixes the **"NEW"** button on **My Account → My Organization → Users** on the **public storefront domain**, which stayed disabled even for users allowed to add organization members.

The real issue was not missing `adminUserEmail` in the session: the License Manager **granted** check returned **401** on the storefront because the request did not send the **`VtexIdclientAutCookie`** header. That value is not available via `document.cookie` (**HttpOnly**), but it is exposed in the session payload under `namespaces.cookie` as `VtexIdclientAutCookie_<account>`.

## What changed

- **`useOrgPermission`**: after the session returns `account`, the session query includes `cookie.VtexIdclientAutCookie_${account}` and passes the value into the LM call.
- **`orgPermissionClient`**: sets the **`VtexIdclientAutCookie`** header on the **granted** request (no extra standalone `/api/sessions` fetch).
- **`CHANGELOG`**: **[Unreleased]** entry updated to describe this behavior.

## How to test

1. Link this branch to a **workspace** and publish the app.
2. **Public store domain**: sign in as a B2B user with permission to manage org users; open **My Organization → Users** and confirm **"NEW"** is enabled when expected.
3. **myvtex / admin** (smoke): open a screen that uses `useOrgPermission` and confirm no regression.

**Workspace:** _[paste link]_

## Screenshots (optional)

Before: "NEW" disabled on the store hostname. After: "NEW" enabled for the same user/role.
<img width="615" height="221" alt="image" src="https://github.com/user-attachments/assets/325fc703-e65b-4dee-b94b-b88ace944913" />

